### PR TITLE
Add missing stdlib Set require to ClassAttribute.

### DIFF
--- a/lib/lotus/utils/class_attribute.rb
+++ b/lib/lotus/utils/class_attribute.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Lotus
   module Utils
     # Inheritable class level variable accessors.


### PR DESCRIPTION
Ran into this trying to `require 'lotus/utils/class_attributes'`:

```
NameError: uninitialized constant Lotus::Utils::ClassAttribute::ClassMethods::Set
from /usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/lotus-utils-0.1.0/lib/lotus/utils/class_attribute.rb:89:in `class_attributes'
```
