### PR TITLE
Adding Lotus::Utils.load_class! convenience method

### DIFF
--- a/lib/lotus/utils/class.rb
+++ b/lib/lotus/utils/class.rb
@@ -2,6 +2,17 @@ require 'lotus/utils/string'
 
 module Lotus
   module Utils
+
+    module_function
+
+    # See Lotus::Utils::Class.load!
+    #
+    # Provided as a convenience method to avoid referencing possibly deeply
+    # nested methods.
+    def load_class!(*args)
+      Class.load!(*args)
+    end
+
     # Class utilities
     # @since 0.1.0
     class Class

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -45,3 +45,50 @@ describe Lotus::Utils::Class do
     end
   end
 end
+
+describe Lotus::Utils do
+  before do
+    module App
+      module Layer
+        class Step
+        end
+      end
+
+      module Service
+        class Point
+        end
+      end
+
+      class ServicePoint
+      end
+    end
+  end
+
+  describe '.load_class!' do
+
+    it 'loads the class from the given static string' do
+      Lotus::Utils.load_class!('App::Layer::Step').must_equal(App::Layer::Step)
+    end
+
+    it 'raises error for missing constant' do
+      -> { Lotus::Utils.load_class!('MissingConstant') }.must_raise(NameError)
+    end
+
+    it 'loads the class from given string, by interpolating tokens' do
+      Lotus::Utils.load_class!('App::Service(::Point|Point)').must_equal(App::Service::Point)
+    end
+
+    it 'loads the class from given string, by interpolating string tokens and respecting their order' do
+      Lotus::Utils.load_class!('App::Service(Point|::Point)').must_equal(App::ServicePoint)
+    end
+
+    it 'loads the class from given string, by interpolating tokens and not stopping after first fail' do
+      Lotus::Utils.load_class!('App::(Layer|Layer::)Step').must_equal(App::Layer::Step)
+    end
+
+    it 'loads class from given string and namespace' do
+      Lotus::Utils.load_class!('(Layer|Layer::)Step', App).must_equal(App::Layer::Step)
+    end
+
+  end
+end


### PR DESCRIPTION
_This pull request is intended to start a conversation._

Instead of referencing nested classes – Lotus::Utils::Class -
provide a convenience method in Lotus::Utils.

When I start thinking about calling a function on a deeply nested
class, I can't help but feel that I'm violating some principle.

Given that Lotus is a framework, would it make sense for the
underlying function call to be easier to substite out? Below is a
rough implementation of what I was thinking.

``` ruby
module Lotus::Utils
  def load_class!(pattern, namespace = Object, options = {})
    load_container = option.fetch(:load_container) { Lotus::Utils::Class }
    load_container.load!(pattern, namespace)
  end
end
```

Questions:
- Is this pattern something that resonates? Would it make sense to
  expose the method at the Lotus level with something like:
  `Lotus.load_class!` or `Lotus.utility_to_load_class!`
- Would this pattern make sense for other Util-based classes?
- Why is Lotus::Utils::Class not a module?
- Would it make sense for Lotus::Utils::Class.load! to be a
  module_function?
