### PR TITLE
Use DelegateClass instead of core class inheiritance

### DIFF
--- a/lib/lotus/utils/hash.rb
+++ b/lib/lotus/utils/hash.rb
@@ -1,8 +1,10 @@
+require 'delegate'
+
 module Lotus
   module Utils
     # Hash on steroids
     # @since 0.1.0
-    class Hash < ::Hash
+    class Hash < DelegateClass(::Hash)
       # Initialize the hash
       #
       # @param hash [::Hash, Hash] the value we want to use to initialize this instance
@@ -11,6 +13,7 @@ module Lotus
       #
       # @since 0.1.0
       def initialize(hash = {})
+        super
         merge! hash
       end
 

--- a/lib/lotus/utils/path_prefix.rb
+++ b/lib/lotus/utils/path_prefix.rb
@@ -1,9 +1,11 @@
+require 'delegate'
+
 module Lotus
   module Utils
     # Prefixed string
     #
     # @since 0.1.0
-    class PathPrefix < ::String
+    class PathPrefix < DelegateClass(::String)
       # Initialize the path prefix
       #
       # @param string [::String] the prefix value

--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -1,9 +1,11 @@
+require 'delegate'
+
 module Lotus
   module Utils
     # String on steroids
     #
     # @since 0.1.0
-    class String < ::String
+    class String < DelegateClass(::String)
       # Separator between Ruby namespaces
       #
       # @example
@@ -41,7 +43,7 @@ module Lotus
 
       # Return a downcased and underscore separated version of the string
       #
-      # Revised version of `ActiveSupport::Inflector.underscore` implementation 
+      # Revised version of `ActiveSupport::Inflector.underscore` implementation
       # @see https://github.com/rails/rails/blob/feaa6e2048fe86bcf07e967d6e47b865e42e055b/activesupport/lib/active_support/inflector/methods.rb#L90
       #
       # @return [String] the transformed string
@@ -117,8 +119,8 @@ module Lotus
       #     'Lotus::Utils'
       #     'Lotus::App'
       def tokenize(&blk)
-        template = gsub(/\((.*)\)/, "%{token}")
-        tokens   = Array(( $1 || self ).split('|'))
+        template = __getobj__.gsub(/\((.*)\)/, "%{token}")
+        tokens   = Array(( $1 || __getobj__ ).split('|'))
 
         tokens.each do |token|
           blk.call(template % {token: token})


### PR DESCRIPTION
Inheiriting from core classes like `String` can cause issues. Let's use `DelegateClass` to avoid the inheiritance.
