### PR TITLE
MethodCallback#hash and MethodCallback#eql? - Rubinius Bug

### DIFF
--- a/lib/lotus/utils/callbacks.rb
+++ b/lib/lotus/utils/callbacks.rb
@@ -225,7 +225,6 @@ module Lotus
           end
         end
 
-        protected
         def hash
           callback.hash
         end


### PR DESCRIPTION
When calling `Lotus::Utils::Callbacks::Chain.new.add :symbolize!` rubinius internal uses `Lotus::Utils::Callbacks::MethodCallback#hash` and `Lotus::Utils::Callbacks::MethodCallback#eql?`

``` ruby
def add(*callbacks, &blk)
  callbacks.push blk if block_given?
  callbacks.each do |c|
    @chain.push Factory.fabricate(c)
  end

  # @chain => [#<Lotus::Utils::Callbacks::MethodCallback:0x14668 @callback=:symbolize!>]
  @chain.uniq!
end
```

In https://github.com/rubinius/rubinius/blob/master/kernel/common/identity_map.rb#L39-L46 `item` is then `#<Lotus::Utils::Callbacks::MethodCallback:0x14668 @callback=:symbolize!>` and trying to call hash on it. Therefore `Lotus::Utils::Callbacks::MethodCallback#hash` has to be public.

``` ruby
def insert(item, &block)
  # item = #<Lotus::Utils::Callbacks::MethodCallback:0x14668 @callback=:symbolize!>
  redistribute if @size > @max

  if block_given?
    item_hash = yield(item).hash
  else
    item_hash = item.hash
  end

...
```

Equivalent is required for `Lotus::Utils::Callbacks::MethodCallback#eql?`
## Possible bug in  Rubinius - Stack Trace:

``` bash
NoMethodError: protected method `hash' called on an instance of Lotus::Utils::Callbacks::MethodCallback.
    kernel/delta/kernel.rb:78:in `hash (method_missing)'
    kernel/common/identity_map.rb:46:in `insert'
    kernel/common/identity_map.rb:256:in `load'
    kernel/bootstrap/array.rb:76:in `each'
    kernel/common/identity_map.rb:256:in `load'
    kernel/bootstrap/array.rb:76:in `each'
    kernel/common/identity_map.rb:255:in `load'
    kernel/common/identity_map.rb:25:in `from'
    kernel/common/array.rb:1650:in `uniq!'
    /home/benny/Web/ruby/lotus-framework/utils/lib/lotus/utils/callbacks.rb:58:in `add'
    /home/benny/Web/ruby/lotus-framework/utils/test/callbacks_test.rb:124:in `__script__'
    kernel/common/eval.rb:43:in `instance_eval'
```

In https://github.com/rubinius/rubinius/blob/master/kernel/common/identity_map.rb#L25 `Rubinius.privately` is used to call the further code.
If I'm right informed `Rubinius.privately` should do kinda the same as `#send` so private & protected methods should be callable.

Trying to make a standalone repro and create a issue on rubinius.

2 Options here:
- Merge this for now
- Wait until bug in rubinius is resolved
