### PR TITLE
Speedup Lotus::Utils::String#tokenize

### DIFF
--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -16,6 +16,18 @@ module Lotus
       # @api private
       CLASSIFY_SEPARATOR  = '_'.freeze
 
+      # Regexp for #tokenize
+      #
+      # @since x.x.x
+      # @api private
+      TOKENIZE_REGEXP     = /\((.*)\)/
+
+      # Separator for #tokenize
+      #
+      # @since x.x.x
+      # @api private
+      TOKENIZE_SEPARATOR  = '|'.freeze
+
       # Initialize the string
       #
       # @param string [::String, Symbol] the value we want to initialize
@@ -120,9 +132,9 @@ module Lotus
       #     'Lotus::Utils'
       #     'Lotus::App'
       def tokenize(&blk)
-        if match = /\((.*)\)/.match(@string)
+        if match = TOKENIZE_REGEXP.match(@string)
           pre, post = match.pre_match, match.post_match
-          tokens = match[1].split('|')
+          tokens = match[1].split(TOKENIZE_SEPARATOR)
           tokens.each do |token|
             blk.call(self.class.new("#{pre}#{token}#{post}"))
           end


### PR DESCRIPTION
Use MatchData with its {pre,post}_match information which is twice as fast as the previous implementation.

See this benchmark https://gist.github.com/splattael/36c933ca8e20377c481d
