### PR TITLE
Add Lotus::String#deconstantize

### DIFF
--- a/lib/lotus/utils/string.rb
+++ b/lib/lotus/utils/string.rb
@@ -93,22 +93,27 @@ module Lotus
         self.class.new split(NAMESPACE_SEPARATOR).last
       end
 
-      # Return the top level namespace name
+      # Return the namespace for Lotus
       #
       # @return [String] the transformed string
       #
-      # @since 0.1.2
+      # @since x.x.x
       #
       # @example
       #   require 'lotus/utils/string'
       #
       #   string = Lotus::Utils::String.new 'Lotus::Utils::String'
-      #   string.namespace # => 'Lotus'
+      #   string.namespace # => 'Lotus::Utils'
       #
       #   string = Lotus::Utils::String.new 'String'
       #   string.namespace # => 'String'
       def namespace
-        self.class.new split(NAMESPACE_SEPARATOR).first
+        parts = split(NAMESPACE_SEPARATOR)
+        if parts.length > 1
+          self.class.new parts.slice(0...-1).join(NAMESPACE_SEPARATOR)
+        else
+          self.class.new parts.first
+        end
       end
 
       # It iterates thru the tokens and calls the given block.

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -61,9 +61,10 @@ describe Lotus::Utils::String do
       Lotus::Utils::String.new('Lotus').namespace.must_be_kind_of(Lotus::Utils::String)
     end
 
-    it 'returns the top level module name' do
+    it 'returns the namespace for Lotus' do
       Lotus::Utils::String.new('String').namespace.must_equal('String')
-      Lotus::Utils::String.new('Lotus::Utils::String').namespace.must_equal('Lotus')
+      Lotus::Utils::String.new('Lotus::Utils::String').namespace.must_equal('Lotus::Utils')
+      Lotus::Utils::String.new('').namespace.must_equal('')
     end
   end
 


### PR DESCRIPTION
Hi.

This PR is required by feature of loading framework to apposite module.
https://github.com/lotus/lotus/pull/67
It give method `#deconstantize` to `Lotus::String`. This returns `Lotus::String` that contains what is without rightmost segment.
