### PR TITLE
Don't bind blocks if not necessary

### DIFF
--- a/lib/lotus/utils/io.rb
+++ b/lib/lotus/utils/io.rb
@@ -9,7 +9,7 @@ module Lotus
       # Revised version of ActiveSupport's `Kernel.with_warnings` implementation
       # @see https://github.com/rails/rails/blob/v4.1.2/activesupport/lib/active_support/core_ext/kernel/reporting.rb#L25
       #
-      # @param blk [Proc] the block of code that generates warnings.
+      # @yield the block of code that generates warnings.
       #
       # @return [void]
       #
@@ -25,9 +25,9 @@ module Lotus
       #   Lotus::Utils::IO.silence_warnings do
       #     Test::TEST_VALUE = 'redefined'
       #   end
-      def self.silence_warnings(&blk)
+      def self.silence_warnings
         old_verbose, $VERBOSE = $VERBOSE, nil
-        blk.call
+        yield
       ensure
         $VERBOSE = old_verbose
       end


### PR DESCRIPTION
Having such benchmark:

```
require 'lotus/utils/io'
require "benchmark/ips"

class Test
  TEST_VALUE = 'initial'
end

module Lotus
  module Utils
    class IO
      def self.fast_silence_warnings
        old_verbose, $VERBOSE = $VERBOSE, nil
        yield
      ensure
        $VERBOSE = old_verbose
      end
    end
  end
end

Benchmark.ips do |x|
  x.report("blk.call") do
    Lotus::Utils::IO.silence_warnings do
      Test::TEST_VALUE = 'redefined'
    end
  end
  x.report("yield") do
    Lotus::Utils::IO.fast_silence_warnings do
      Test::TEST_VALUE = 'redefined'
    end
  end
end
```

yields such results:

```
Calculating -------------------------------------
            blk.call     36488 i/100ms
               yield     48849 i/100ms
-------------------------------------------------
            blk.call   600473.5 (±2.1%) i/s -    3028504 in   5.045644s
               yield  1046803.7 (±1.9%) i/s -    5275692 in   5.041649s
```

Yield version is ~75% faster. Therefore I replaces blk.call with yield and updated the doc. 

I also reviewed Lotus::Utils::LoadPaths#each for the same case, but it provided an improvement for ~3.2%, so I decided not to include it.
