### PR TITLE
Improved error NameError message by passing in the whole constant name

### DIFF
--- a/lib/lotus/utils/class.rb
+++ b/lib/lotus/utils/class.rb
@@ -52,7 +52,7 @@ module Lotus
           end
         end
 
-        raise NameError.new(name)
+        raise NameError.new("#{namespace}::#{name}")
       end
     end
   end

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -28,6 +28,11 @@ describe Lotus::Utils::Class do
       -> { Lotus::Utils::Class.load!('MissingConstant') }.must_raise(NameError)
     end
 
+    it 'raises error with full constant name' do
+      error = -> { Lotus::Utils::Class.load!('Step', App) }.must_raise(NameError)
+      assert_match(/App::Step/, error.message)
+    end
+
     it 'loads the class from given string, by interpolating tokens' do
       Lotus::Utils::Class.load!('App::Service(::Point|Point)').must_equal(App::Service::Point)
     end


### PR DESCRIPTION
Improved NameError message so it clearly shows the full constant name that Lotus is looking for.
