### PR TITLE
Faster and less memory intensive Utils::Kernel.Array

### DIFF
--- a/lib/lotus/utils/kernel.rb
+++ b/lib/lotus/utils/kernel.rb
@@ -70,7 +70,11 @@ module Lotus
       #   response = Response.new(200, {}, 'hello')
       #   Lotus::Utils::Kernel.Array(response)         # => [200, {}, "hello"]
       def self.Array(arg)
-        super(arg).flatten.compact.uniq
+        super(arg).dup.tap do |a|
+          a.flatten!
+          a.compact!
+          a.uniq!
+        end
       end
 
       # Coerces the argument to be a set.

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -73,6 +73,10 @@ describe Lotus::Utils::Kernel do
         it 'returns a flatten array' do
           @result.must_equal [1,2,3]
         end
+
+        it "doesn't change the argument" do
+          input.must_equal [1, [2, 3]]
+        end
       end
 
       describe 'when an array with nil values is given' do
@@ -88,6 +92,10 @@ describe Lotus::Utils::Kernel do
 
         it 'returns an array with uniq values' do
           @result.must_equal [2,3]
+        end
+
+        it "doesn't change the argument" do
+          input.must_equal [2, [2, 3]]
         end
       end
 


### PR DESCRIPTION
**TL;DR** It's a little bit faster, but allocates 1/3 less objects.

```
BENCHMARK:

Calculating -------------------------------------
                 old       455 i/100ms
                 new       476 i/100ms
-------------------------------------------------
                 old     4702.9 (±4.0%) i/s -      23660 in   5.039263s
                 new     4800.3 (±6.2%) i/s -      24276 in   5.080260s

OBJECTS ALLOCATIONS:

Allocations for old:
 sourcefile    sourceline  class  count
-------------  ----------  -----  -----
arraybench.rb           9  Array   3000

Allocations for new:
 sourcefile    sourceline  class  count
-------------  ----------  -----  -----
arraybench.rb          20  Array   1000
arraybench.rb          21  Array   1000
```

Source available at: https://gist.github.com/jodosha/c034ac73939aa4c769db
