### PR TITLE
Adding Lotus::Utils::Kernel::Clone function

### DIFF
--- a/lib/lotus/utils/kernel.rb
+++ b/lib/lotus/utils/kernel.rb
@@ -3,6 +3,7 @@ require 'date'
 require 'time'
 require 'pathname'
 require 'bigdecimal'
+require 'deep_clone'
 
 # Define top level constant Boolean, so it can be easily used by other libraries
 # in coercions DSLs
@@ -988,6 +989,27 @@ module Lotus
         end
       rescue NoMethodError
         raise TypeError.new "can't convert into Symbol"
+      end
+
+      # Creates a deep clone of the argument.
+      #
+      # @param arg [Object] the argument
+      #
+      # @return [Object] the result of the cloning process
+      #
+      # @since 0.3.1
+      #
+      # @example Basic Usage
+      #   require 'lotus/utils/kernel'
+      #
+      #   hash = { a: 'one', b: { c: 'two' } }
+      #   clone = Lotus::Utils::Kernel.Clone(hash)
+      #   hash == clone # => true
+      #   hash.object_id == clone.object_id # => false
+      #   hash[:a].object_id == clone[:a].object_id # => false
+      #   hash[:b][:c].object_id == clone[:b][:c].object_id # => false
+      def self.Clone(arg)
+        DeepClone.clone(arg)
       end
     end
   end

--- a/lotus-utils.gemspec
+++ b/lotus-utils.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.0.0'
 
+  spec.add_dependency 'ruby_deep_clone', '~> 0.6'
+
   spec.add_development_dependency 'bundler',  '~> 1.6'
   spec.add_development_dependency 'rake',     '~> 10'
   spec.add_development_dependency 'minitest', '~> 5.4'

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -2458,4 +2458,26 @@ describe Lotus::Utils::Kernel do
       end
     end
   end
+
+  describe '.Clone' do
+    describe 'a complex object' do
+      let(:input) { { key: { sub_key: 'value' } } }
+      before do
+        @clone = Lotus::Utils::Kernel.Clone(input)
+      end
+
+      it 'creates a clone that is equal to the input' do
+        @clone.must_equal input
+      end
+
+      it 'creates a clone with a different object_id' do
+        @clone.object_id.wont_equal input.object_id
+      end
+
+      it 'creates a clone of composite objects' do
+        @clone[:key].object_id.wont_equal input[:key].object_id
+        @clone[:key][:sub_key].object_id.wont_equal input[:key][:sub_key].object_id
+      end
+    end
+  end
 end


### PR DESCRIPTION
Providing a public API function for creating a cloned object. A cloned
object should be a deep clone of the object.

I have placed this in Kernel as it is a conversion function. However
based on usage, it may need a different place.

This commit also introduces an external dependency which could be
factored away.

Related to lotus/validations#23
