### PR TITLE
do not pass the block to `String#chars`

### DIFF
--- a/lib/hanami/utils/escape.rb
+++ b/lib/hanami/utils/escape.rb
@@ -423,7 +423,7 @@ module Hanami
 
         result = SafeString.new
 
-        input.chars do |chr|
+        input.each_char do |chr|
           result << HTML_CHARS.fetch(chr, chr)
         end
 
@@ -456,7 +456,7 @@ module Hanami
 
         result = SafeString.new
 
-        input.chars do |chr|
+        input.each_char do |chr|
           result << encode_char(chr, HTML_ATTRIBUTE_SAFE_CHARS)
         end
 


### PR DESCRIPTION
Since Ruby 2.0.0, `String#chars` returns an array instead of an enumerator. Passing a block is deprecated.

ref: https://github.com/ruby/ruby/commit/3f9b0936aa846bdf6984019ca40bc629fe05d929