### PR TITLE
Class `.to_s` on objects when encoding them

### DIFF
--- a/lib/hanami/utils/escape.rb
+++ b/lib/hanami/utils/escape.rb
@@ -529,7 +529,7 @@ module Hanami
       # @api private
       def self.encode(input)
         return '' if input.nil?
-        input.encode(Encoding::UTF_8)
+        input.to_s.encode(Encoding::UTF_8)
       rescue Encoding::UndefinedConversionError
         input.dup.force_encoding(Encoding::UTF_8)
       end

--- a/test/escape_test.rb
+++ b/test/escape_test.rb
@@ -339,6 +339,28 @@ describe Hanami::Utils::Escape do
           result.must_equal 'http://x.xx/@'
         end
       end
+
+      describe 'encodes non-String objects that respond to `.to_s`' do
+        TEST_ENCODINGS.each do |encoding|
+          describe "#{ encoding }" do
+
+            it "escapes a Date" do
+              result = mod.html(Date.new(2016,01,27))
+              result.must_equal "2016-01-27"
+            end
+
+            it "escapes a Time" do
+              result = mod.html(Time.new(2016,01,27, 12, 0, 0, 0))
+              result.must_equal "2016-01-27 12:00:00 +0000"
+            end
+
+            it "escapes a DateTime" do
+              result = mod.html(DateTime.new(2016,01,27, 12, 0, 0, 0))
+              result.must_equal "2016-01-27T12:00:00+00:00"
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In `0.5.0` you can directly escape (`encode`) a `Date` object. In `0.6.0` +, you have to manually call `.to_s` first. This partially reverts [this commit](https://github.com/hanami/utils/commit/9221338890dc9e7361509fbfc03d14bf94616ec1).

In the `rescue Encoding::UndefinedConversionError` block, I haven't added calling this `.to_s` call. Should we add it there too? I'm not really sure how that code works.
 
I've added regression tests for:

- Time
- Date
- DateTime

Are there any other Classes we should test for?

Closes #113, @davydovanton !