### PR TITLE
Utils::Hash #symbolize! and #stringify! supporst nested Utils::Hash values

### DIFF
--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -65,7 +65,7 @@ module Hanami
       def symbolize!
         keys.each do |k|
           v = delete(k)
-          v = Hash.new(v).symbolize! if v.is_a?(::Hash)
+          v = Hash.new(v).symbolize! if v.is_a?(::Hash) || v.is_a?(::Hanami::Utils::Hash)
 
           self[k.to_sym] = v
         end
@@ -90,7 +90,7 @@ module Hanami
       def stringify!
         keys.each do |k|
           v = delete(k)
-          v = Hash.new(v).stringify! if v.is_a?(::Hash)
+          v = Hash.new(v).stringify! if v.is_a?(::Hash) || v.is_a?(::Hanami::Utils::Hash)
 
           self[k.to_s] = v
         end

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -40,6 +40,15 @@ describe Hanami::Utils::Hash do
       hash[:nested].must_be_kind_of Hanami::Utils::Hash
       hash[:nested][:key].must_equal('value')
     end
+
+    it 'symbolize nested Hanami::Utils::Hashes' do
+      nested = Hanami::Utils::Hash.new('key' => 'value')
+      hash = Hanami::Utils::Hash.new('nested' => nested)
+      hash.symbolize!
+
+      hash[:nested].must_be_kind_of Hanami::Utils::Hash
+      hash[:nested][:key].must_equal('value')
+    end
   end
 
   describe '#stringify!' do
@@ -53,6 +62,15 @@ describe Hanami::Utils::Hash do
 
     it 'stringifies nested hashes' do
       hash = Hanami::Utils::Hash.new(nested: {key: 'value'})
+      hash.stringify!
+
+      hash['nested'].must_be_kind_of Hanami::Utils::Hash
+      hash['nested']['key'].must_equal('value')
+    end
+
+    it 'stringifies nested Hanami::Utils::Hashes' do
+      nested = Hanami::Utils::Hash.new(key: 'value')
+      hash = Hanami::Utils::Hash.new(nested: nested)
       hash.stringify!
 
       hash['nested'].must_be_kind_of Hanami::Utils::Hash


### PR DESCRIPTION
Hi,

This pull request adds support for `symbolize!` and `stringify!`with nested `Hanami::Utils::Hash` as values.

I'm not sure if there is a reason not to do this, or maybe there are a better way of implementing this. For instance: [ActiveSupport::TimeWithZone](https://github.com/rails/rails/blob/0e528b626cb164153dea45b4528888ef663cad83/activesupport/lib/active_support/time_with_zone.rb#L334) do override `is_a?` so it returns `true` when asked if `time_with_zone.is_a? Time`. Some tests broke when went this way with `Utils::Hash`.