### PR TITLE
[b] Utils::String#classify "AwesomeProject" => "Awesomeproject"

### DIFF
--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -141,7 +141,7 @@ module Hanami
       #   string = Hanami::Utils::String.new 'hanami_utils'
       #   string.classify # => 'HanamiUtils'
       def classify
-        words = split(CLASSIFY_WORD_SEPARATOR).map!(&:capitalize)
+        words = underscore.split(CLASSIFY_WORD_SEPARATOR).map!(&:capitalize)
         delimiters = scan(CLASSIFY_WORD_SEPARATOR)
 
         delimiters.map! do |delimiter|

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -83,6 +83,10 @@ describe Hanami::Utils::String do
       Hanami::Utils::String.new(:'hanami/router').classify.must_equal('Hanami::Router')
       Hanami::Utils::String.new(:'hanami::router').classify.must_equal('Hanami::Router')
     end
+
+    it 'does not remove capital letter in string' do
+      Hanami::Utils::String.new("AwesomeProject").classify.must_equal("AwesomeProject")
+    end
   end
 
   describe '#underscore' do


### PR DESCRIPTION
- Adding `underscore` before splitting word so that `capitalize` does not make `p` become lowercase.

Fix #119 