### PR TITLE
Removing warnings for URI.extract and URI.unescape because these methods are now obsolete

### DIFF
--- a/lib/hanami/utils/escape.rb
+++ b/lib/hanami/utils/escape.rb
@@ -511,8 +511,8 @@ module Hanami
         return input if input.is_a?(SafeString)
 
         SafeString.new(
-          URI.extract(
-            URI.decode(input),
+          URI::Parser.new.extract(
+            URI.decode_www_form_component(input),
             schemes
           ).first.to_s
         )


### PR DESCRIPTION
Here are the warnings:

```
../lib/hanami/utils/escape.rb:514:in `url': warning: URI.extract is obsolete
../lib/hanami/utils/escape.rb:515:in `url': warning: URI.unescape is obsolete
```

This solves the problems reported in #127 and #128.