### PR TITLE
Fix broken tests for logger class

### DIFF
--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -128,46 +128,33 @@ describe Hanami::Logger do
         end # end loop
 
         describe 'when file' do
-          let(:stream) { File.new(Pathname.new('tmp').join('logfile.log'), 'w+', permissions) }
+          let(:stream)      { Pathname.new('tmp').join('logfile.log') }
+          let(:log_file)    { File.new(stream, 'w+', permissions) }
           let(:permissions) { 0644 }
 
-          describe 'and brand new' do
-            before do
-              stream.write('hello')
-            end
-
-            it 'appends to file' do
-              logger = Hanami::Logger.new(stream: stream)
-              logger.info('world')
-
-              logger.close
-
-              contents = File.read(stream)
-              contents.must_match(/hello/)
-              contents.must_match(/world/)
-            end
+          before(:each) do
+            log_file.write('hello')
           end
 
           describe 'and already written' do
-            before do
-              stream.write('hello')
-            end
-
             it 'appends to file' do
-              logger = Hanami::Logger.new(stream: stream)
+              logger = Hanami::Logger.new(stream: log_file)
               logger.info('world')
 
               logger.close
 
-              contents = File.read(stream)
+              contents = File.read(log_file)
               contents.must_match(/hello/)
               contents.must_match(/world/)
             end
 
             it 'does not change permissions' do
-              logger = Hanami::Logger.new(stream: stream)
+              logger = Hanami::Logger.new(stream: log_file)
               logger.info('appended')
               logger.close
+
+              stat = File.stat(log_file)
+              stat.mode.to_s(8).must_equal('100644')
             end
           end
         end # end File


### PR DESCRIPTION
Fixed #132.
I found that `'custom stream file system'` group have a `before` callback [on the top of group][callback]. This callback create new `tmp` path and use `stream` value for this.

My patch fixed naming problems, also I removed unnecessary test and completed test for file permission.

Thanks @rogeriozambon for his [bash code][bashcode]. On my local machine all works fine:
![screenshot 2016-03-23 17 11 07](https://cloud.githubusercontent.com/assets/1147484/13987979/77ce8470-f123-11e5-89b9-91abeae18612.jpg)

/cc @hanami/core-team @hanami/contributors 

[callback]: https://github.com/hanami/utils/blob/master/test/logger_test.rb#L73-L75
[bashcode]: https://github.com/hanami/utils/issues/132#issuecomment-200177326
