### PR TITLE
Allow deep indifferent access on Hanami::Utils::Attributes

### DIFF
--- a/lib/hanami/utils/attributes.rb
+++ b/lib/hanami/utils/attributes.rb
@@ -66,7 +66,16 @@ module Hanami
       #   attributes[:unknown]      # => nil
       #   attributes['unknown']     # => nil
       def get(attribute)
-        @attributes[attribute.to_s]
+        value = @attributes
+
+        keys = attribute.to_s.split('.')
+        keys.each do |key|
+          break unless value
+
+          value = value[key]
+        end
+
+        value.kind_of?(Hash) ? self.class.new(value) : value
       end
 
       # @since 0.3.4

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -51,6 +51,19 @@ describe Hanami::Utils::Attributes do
       attributes.get('23').must_equal 'foo'
     end
 
+    it 'allows deep indifferent access' do
+      attributes = Hanami::Utils::Attributes.new(foo: {baz: 'bar'})
+      attributes.get(:foo).get(:baz).must_equal 'bar'
+      attributes.get(:foo).get('baz').must_equal 'bar'
+      attributes.get('foo').get(:baz).must_equal 'bar'
+      attributes.get('foo').get('baz').must_equal 'bar'
+    end
+
+    it 'allows deep access via nested key string' do
+      attributes = Hanami::Utils::Attributes.new(foo: {baz: 'bar'})
+      attributes.get('foo.baz').must_equal 'bar'
+    end
+
     it 'correctly handles Ruby falsey' do
       attributes = Hanami::Utils::Attributes.new('foo' => false)
       attributes.get(:foo).must_equal  false
@@ -90,6 +103,19 @@ describe Hanami::Utils::Attributes do
       attributes = Hanami::Utils::Attributes.new( 23 => 'foo')
       attributes[23].must_equal   'foo'
       attributes['23'].must_equal 'foo'
+    end
+
+    it 'allows deep indifferent access' do
+      attributes = Hanami::Utils::Attributes.new(foo: {baz: 'bar'})
+      attributes[:foo][:baz].must_equal 'bar'
+      attributes[:foo]['baz'].must_equal 'bar'
+      attributes['foo'][:baz].must_equal 'bar'
+      attributes['foo']['baz'].must_equal 'bar'
+    end
+
+    it 'allows deep access via nested key string' do
+      attributes = Hanami::Utils::Attributes.new(foo: {baz: 'bar'})
+      attributes['foo.baz'].must_equal 'bar'
     end
 
     it 'correctly handles Ruby falsey' do


### PR DESCRIPTION
Address https://github.com/hanami/controller/issues/70 by making `Hanami::Utils::Attribute#get` return `Hanami::Utils::Attributes` for hash-like attribute values.