### PR TITLE
Making sure that only current namespace is checked when loading classes.

### DIFF
--- a/lib/hanami/utils/class.rb
+++ b/lib/hanami/utils/class.rb
@@ -38,7 +38,7 @@ module Hanami
       #   # with missing constant
       #   Hanami::Utils::Class.load!('Unknown') # => raises NameError
       def self.load!(name, namespace = Object)
-        namespace.const_get(name.to_s)
+        namespace.const_get(name.to_s, false)
       end
 
       # Loads a class for the given name, only if it's defined.
@@ -69,7 +69,7 @@ module Hanami
       #   # with explicit namespace
       #   Hanami::Utils::Class.load('Service', App) # => App::Service
       def self.load(name, namespace = Object)
-        load!(name, namespace) if namespace.const_defined?(name.to_s)
+        load!(name, namespace) if namespace.const_defined?(name.to_s, false)
       end
 
       # Loads a class from the given pattern name and namespace
@@ -112,7 +112,7 @@ module Hanami
       def self.load_from_pattern!(pattern, namespace = Object)
         String.new(pattern).tokenize do |token|
           begin
-            return namespace.const_get(token)
+            return namespace.const_get(token, false)
           rescue NameError # rubocop:disable Lint/HandleExceptions
           end
         end

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -3,6 +3,20 @@ require 'hanami/utils/class'
 
 describe Hanami::Utils::Class do
   before do
+    class Bar
+      def level
+        "top"
+      end
+    end
+
+    class Foo
+      class Bar
+        def level
+          "nested"
+        end
+      end
+    end
+
     module App
       module Layer
         class Step
@@ -56,6 +70,21 @@ describe Hanami::Utils::Class do
   end
 
   describe '.load_from_pattern!' do
+    it 'loads the class within the given namespace' do
+      klass = Hanami::Utils::Class.load_from_pattern!('(Hanami|Foo)::Bar')
+      klass.new.level.must_equal 'nested'
+    end
+
+    it 'loads the class within the given namespace, when first namespace does not exist' do
+      klass = Hanami::Utils::Class.load_from_pattern!('(NotExisting|Foo)::Bar')
+      klass.new.level.must_equal 'nested'
+    end
+
+    it 'loads the class within the given namespace when first namespace in pattern is correct one' do
+      klass = Hanami::Utils::Class.load_from_pattern!('(Foo|Hanami)::Bar')
+      klass.new.level.must_equal 'nested'
+    end
+
     it 'loads the class from the given static string' do
       Hanami::Utils::Class.load_from_pattern!('App::Layer::Step').must_equal(App::Layer::Step)
     end

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -5,14 +5,14 @@ describe Hanami::Utils::Class do
   before do
     class Bar
       def level
-        "top"
+        'top'
       end
     end
 
     class Foo
       class Bar
         def level
-          "nested"
+          'nested'
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/hanami/utils/issues/151


Honestly i'm not sure about the side-effects of this to current hanami. But I think the behavior described in issue 151 is a bug.