### PR TITLE
Make Utils::Hash compatible w/ objects that respond to `#to_hash`

### DIFF
--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -65,7 +65,7 @@ module Hanami
       def symbolize!
         keys.each do |k|
           v = delete(k)
-          v = self.class.new(v).symbolize! if v.is_a?(::Hash) || v.is_a?(self.class)
+          v = self.class.new(v).symbolize! if v.respond_to?(:to_hash)
 
           self[k.to_sym] = v
         end
@@ -90,7 +90,7 @@ module Hanami
       def stringify!
         keys.each do |k|
           v = delete(k)
-          v = self.class.new(v).stringify! if v.is_a?(::Hash) || v.is_a?(self.class)
+          v = self.class.new(v).stringify! if v.respond_to?(:to_hash)
 
           self[k.to_s] = v
         end
@@ -224,7 +224,7 @@ module Hanami
       # @see http://www.ruby-doc.org/core/Hash.html#method-i-to_h
       def to_h
         @hash.each_with_object({}) do |(k, v), result|
-          v = v.to_h if v.is_a?(self.class)
+          v = v.to_h if v.respond_to?(:to_hash)
           result[k] = v
         end
       end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -613,3 +613,14 @@ Hanami::Utils::Inflector.inflections do
   exception   'alga',     'algae'
   uncountable 'music', 'butter'
 end
+
+class WrappingHash
+  def initialize(hash)
+    @hash = hash.to_h
+  end
+
+  def to_hash
+    @hash
+  end
+  alias to_h to_hash
+end

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -49,6 +49,14 @@ describe Hanami::Utils::Hash do
       hash[:nested].must_be_kind_of Hanami::Utils::Hash
       hash[:nested][:key].must_equal('value')
     end
+
+    it 'symbolize nested object that responds to to_hash' do
+      nested = Hanami::Utils::Hash.new('metadata' => WrappingHash.new('coverage' => 100))
+      nested.symbolize!
+
+      nested[:metadata].must_be_kind_of Hanami::Utils::Hash
+      nested[:metadata][:coverage].must_equal(100)
+    end
   end
 
   describe '#stringify!' do
@@ -75,6 +83,14 @@ describe Hanami::Utils::Hash do
 
       hash['nested'].must_be_kind_of Hanami::Utils::Hash
       hash['nested']['key'].must_equal('value')
+    end
+
+    it 'stringifies nested object that responds to to_hash' do
+      nested = Hanami::Utils::Hash.new(metadata: WrappingHash.new(coverage: 100))
+      nested.stringify!
+
+      nested['metadata'].must_be_kind_of Hanami::Utils::Hash
+      nested['metadata']['coverage'].must_equal(100)
     end
   end
 
@@ -232,6 +248,11 @@ describe Hanami::Utils::Hash do
 
       #   actual.to_h.must_equal({'a' => {'b' => 2}})
       # end
+
+      it 'serializes nested objects that respond to to_hash' do
+        nested = Hanami::Utils::Hash.new(metadata: WrappingHash.new(coverage: 100))
+        nested.to_h.must_equal(metadata: { coverage: 100 })
+      end
     end
 
     describe '#to_hash' do


### PR DESCRIPTION
Enhanced behavior for:

  * `#symbolize!`
  * `#stringify!`
  * `#to_h`