### PR TITLE
Introducing Hanami::Events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,11 @@ group :multi_json do
   gem 'multi_json', '~> 1.0', require: false
 end
 
-gem 'minitest', '~> 5.9'
-gem 'gson',     '>= 0.6',  require: false, platforms: :jruby
-gem 'rubocop',  '~> 0.41', require: false
-gem 'coveralls',           require: false
+group :events do
+  gem 'concurrent-ruby', '~> 1.0', require: false
+end
+
+gem 'minitest',  '~> 5.9'
+gem 'gson',      '>= 0.6',  require: false, platforms: :jruby
+gem 'rubocop',   '~> 0.41', require: false
+gem 'coveralls',            require: false

--- a/lib/hanami/events.rb
+++ b/lib/hanami/events.rb
@@ -1,0 +1,180 @@
+require 'hanami/utils/class_attribute'
+begin
+  require 'concurrent'
+rescue LoadError
+  raise "Cannot find `concurrent-ruby' gem, please install it and retry."
+end
+
+module Hanami
+  # Event framework for Hanami
+  #
+  # @since x.x.x
+  module Events
+    # Backends for Hanami::Events
+    #
+    # @since x.x.x
+    module Backends
+      # Memory backend for Hanami::Events
+      #
+      # @since x.x.x
+      # @api private
+      class Memory
+        # Instantiate a new memory backend
+        #
+        # @return [Hanami::Events::Backends::Memory] a new instance
+        #
+        # @since x.x.x
+        # @api private
+        def initialize
+          @topics = Concurrent::Map.new { |h, k| h[k] = Concurrent::Array.new }
+        end
+
+        # Subscribe to a topic
+        #
+        # @param topic [String,Symbol] the topic
+        # @param subscriber [#call] the subscriber
+        #
+        # @since x.x.x
+        # @api private
+        def subscribe(topic, subscriber)
+          topics[topic.to_sym].push(subscriber)
+        end
+
+        # Broadcast an event for a given topic
+        #
+        # @param topic [String,Symbol] the topic
+        # @param event [Hanami::Events::Event] the event
+        #
+        # @since x.x.x
+        # @api private
+        def broadcast(topic, event)
+          topics[topic.to_sym].each do |subscriber|
+            subscriber.call(event)
+          end
+        end
+
+        private
+
+        # @since x.x.x
+        # @api private
+        attr_reader :topics
+      end
+    end
+
+    # Broadcasted Event
+    #
+    # @since x.x.x
+    class Event
+      # Instantiate a new event
+      #
+      # @param [#to_hash,#to_h] the payload
+      #
+      # @return [Hanami::Events::Event] a new instance
+      #
+      # @since x.x.x
+      # @api private
+      def initialize(payload)
+        @payload = Utils::Hash.new(payload).symbolize!.freeze
+      end
+
+      # Return the value associated to the given key
+      #
+      # @param [Symbol] the key
+      #
+      # @return [Object,NilClass] the value, if present
+      #
+      # @since x.x.x
+      def [](key)
+        @payload[key]
+      end
+    end
+
+    include Utils::ClassAttribute
+
+    # Support multiple backend for the future.
+    #
+    # For now the only backend is Hanami::Events::Backends::Memory
+    #
+    # @since x.x.x
+    # @api private
+    class_attribute :backend
+    self.backend = Backends::Memory.new
+
+    # Subscribe to a topic
+    #
+    # @param topic [String,Symbol] the topic
+    # @param subscriber [#call] the subscriber (object)
+    # @param blk [Proc] the subscriber (proc)
+    #
+    # @since x.x.x
+    #
+    # @example Subscribe With An Object
+    #   require 'hanami/events'
+    #
+    #   class WelcomeMailer
+    #     def call(event)
+    #       # do something with event
+    #     end
+    #   end
+    #
+    #   Hanami::Events.subscribe('welcome', WelcomeMailer.new)
+    #
+    # @example Subscribe With A Proc
+    #   require 'hanami/events'
+    #
+    #   Hanami::Events.subscribe('welcome') do |event|
+    #     # do something with event
+    #   end
+    def self.subscribe(topic, subscriber = nil, &blk)
+      backend.subscribe(topic, subscriber || blk)
+    end
+
+    # Broadcast an event for a given topic
+    #
+    # @param topic [String,Symbol] the topic
+    # @param event [#to_hash,#to_h] the payload
+    #
+    # @since x.x.x
+    #
+    # @example
+    #   require 'hanami/events'
+    #
+    #   Hanami::Events.subscribe('signup') do |event|
+    #     puts "Welcome #{event[:user].name}"
+    #   end
+    #
+    #   user = User.new(name: "Luca")
+    #   Hanami::Events.broadcast('signup', user: user)
+    #
+    #     # => "Welcome Luca"
+    def self.broadcast(topic, payload)
+      backend.broadcast(topic, Event.new(payload))
+    end
+
+    private
+
+    # Broadcast an event for a given topic
+    #
+    # @param topic [String,Symbol] the topic
+    # @param event [#to_hash,#to_h] the payload
+    #
+    # @since x.x.x
+    #
+    # @see Hanami::Events.broadcast
+    #
+    # @example
+    #   require 'hanami/events'
+    #
+    #   class Signup
+    #     include Hanami::Events
+    #
+    #     def call(params)
+    #       user = User.new(params)
+    #       broadcast('signup', user: user)
+    #     end
+    #   end
+    def broadcast(topic, payload)
+      Events.broadcast(topic, payload)
+    end
+  end
+end

--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -44,7 +44,7 @@ module Hanami
       #
       #   hash.to_h # => { 'foo' => ['bar'] }
       def initialize(hash = {}, &blk)
-        @hash = hash.to_h
+        @hash = hash.respond_to?(:to_hash) ? hash.to_hash : hash.to_h
         @hash.default_proc = blk
       end
 
@@ -165,6 +165,16 @@ module Hanami
         end
       end
 
+      # Freezes itself, the inner hash, and the values
+      #
+      # @since x.x.x
+      def freeze
+        @hash.freeze
+        each_value(&:freeze)
+        super
+        self
+      end
+
       # Returns a new array populated with the keys from this hash
       #
       # @return [Array] the keys
@@ -174,6 +184,17 @@ module Hanami
       # @see http://www.ruby-doc.org/core/Hash.html#method-i-keys
       def keys
         @hash.keys
+      end
+
+      # Iterate through values an yields given block
+      #
+      # @param blk [Proc] a block to be yielded for each iteration
+      #
+      # @since x.x.x
+      #
+      # @see http://ruby-doc.org/core/Hash.html#method-i-each_value
+      def each_value(&blk)
+        @hash.each_value(&blk)
       end
 
       # Deletes the key-value pair and returns the value from hsh whose key is

--- a/test/events/event_test.rb
+++ b/test/events/event_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+require 'hanami/events'
+require 'hanami/utils/hash'
+
+describe Hanami::Events::Event do
+  let(:described_class) { Hanami::Events::Event }
+
+  describe '#initialize' do
+    it 'accepts Hash' do
+      payload = { a: 1 }
+      event   = described_class.new(payload)
+
+      event[:a].must_equal(1)
+    end
+
+    it 'accepts Hanami::Utils::Hash' do
+      payload = Hanami::Utils::Hash.new(a: 1)
+      event   = described_class.new(payload)
+
+      event[:a].must_equal(1)
+    end
+
+    it 'accepts #to_h' do
+      payload = Class.new do
+        def to_h
+          { a: 1 }
+        end
+      end.new
+
+      event = described_class.new(payload)
+
+      event[:a].must_equal(1)
+    end
+
+    it 'accepts #to_hash' do
+      payload = Class.new do
+        def to_hash
+          { a: 1 }
+        end
+      end.new
+
+      event = described_class.new(payload)
+
+      event[:a].must_equal(1)
+    end
+
+    it 'symbolizes keys' do
+      payload = { 'a' => 1 }
+      event   = described_class.new(payload)
+
+      event[:a].must_equal(1)
+    end
+
+    it 'freezes payload' do
+      payload = { a: [1, 2, 3] }
+      event   = described_class.new(payload)
+
+      lambda do
+        event[:a].push(4)
+      end.must_raise(RuntimeError)
+    end
+  end
+
+  describe '#[]' do
+    it 'returns value' do
+      event = described_class.new(a: 1)
+
+      event[:a].must_equal(1)
+    end
+
+    it "doesn't allow indifferent access" do
+      event = described_class.new(a: 1)
+
+      event['a'].must_equal(nil)
+    end
+
+    it 'returns nil for unknown key' do
+      event = described_class.new(a: 1)
+
+      event[:unknown].must_equal(nil)
+    end
+  end
+end

--- a/test/events_test.rb
+++ b/test/events_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+require 'hanami/events'
+require 'ostruct'
+
+describe Hanami::Events do
+  before do
+    Hanami::Events.backend = Hanami::Events::Backends::Memory.new
+  end
+
+  describe '.subscribe' do
+    it 'allows to subscribe with a proc' do
+      Hanami::Events.subscribe('foo') do |event|
+      end
+    end
+
+    it 'allows to subscribe with an object' do
+      subscriber = ->(event) {}
+      Hanami::Events.subscribe('bar', subscriber)
+    end
+  end
+
+  describe '.broadcast' do
+    it 'broadcasts an event' do
+      mailer = Class.new do
+        def call(event)
+          puts "welcome email for: #{event[:user].email}"
+        end
+      end.new
+
+      Hanami::Events.subscribe('signup', mailer)
+      Hanami::Events.subscribe('signup') do |event|
+        puts "new user signed up: #{event[:user].id}"
+      end
+
+      user = OpenStruct.new(id: 1, email: 'user@hanamirb.org')
+      out, = capture_io do
+        Hanami::Events.broadcast('signup', user: user)
+      end
+
+      out.must_include('welcome email for: user@hanamirb.org')
+      out.must_include('new user signed up: 1')
+    end
+  end
+
+  describe 'when included' do
+    let(:signup) do
+      Class.new do
+        include Hanami::Events
+
+        def call(input)
+          user = OpenStruct.new(input)
+
+          broadcast('welcome',          user: user)
+          broadcast('analytics.update', user: user)
+        end
+      end
+    end
+
+    it "won't respond to .backend" do
+      signup.wont_respond_to(:backend)
+    end
+
+    it "won't respond to .subscribe" do
+      signup.wont_respond_to(:subscribe)
+    end
+
+    it "won't respond to .broadcast" do
+      signup.wont_respond_to(:broadcast)
+    end
+
+    describe '#broadcast' do
+      it 'broadcasts an event' do
+        Hanami::Events.subscribe('welcome') do |event|
+          puts "display welcome message for #{event[:user].id}"
+        end
+
+        Hanami::Events.subscribe('analytics.update') do |event|
+          puts "update analytics for #{event[:user].id}"
+        end
+
+        out, = capture_io do
+          signup.new.call(id: 23)
+        end
+
+        out.must_include('display welcome message for 23')
+        out.must_include('update analytics for 23')
+      end
+    end
+  end
+end

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -22,6 +22,28 @@ describe Hanami::Utils::Hash do
 
       hash.to_h.must_be_kind_of(::Hash)
     end
+
+    it 'accepts #to_hash' do
+      arg = Class.new do
+        def to_hash
+          { 'foo' => 'bar' }
+        end
+      end.new
+
+      hash = Hanami::Utils::Hash.new(arg)
+      hash['foo'].must_equal('bar')
+    end
+
+    it 'accepts #to_h' do
+      arg = Class.new do
+        def to_h
+          { 'foo' => 'bar' }
+        end
+      end.new
+
+      hash = Hanami::Utils::Hash.new(arg)
+      hash['foo'].must_equal('bar')
+    end
   end
 
   describe '#symbolize!' do
@@ -148,6 +170,21 @@ describe Hanami::Utils::Hash do
 
       duped['foo'].must_be_kind_of(::Hash)
       duped['x'].must_be_kind_of(Hanami::Utils::Hash)
+    end
+  end
+
+  describe '#freeze' do
+    it 'deep freezes' do
+      hash = Hanami::Utils::Hash.new(
+        a: [1, 2, 3],
+        hash: Hanami::Utils::Hash.new(a: 1)
+      ).freeze
+
+      exception = -> { hash[:a].push(4) }.must_raise(RuntimeError)
+      exception.message.must_equal "can't modify frozen Array"
+
+      exception = -> { hash[:hash].merge!(foo: 'bar') }.must_raise(RuntimeError)
+      exception.message.must_equal "can't modify frozen Hash"
     end
   end
 

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'bigdecimal'
+require 'hanami/utils'
 require 'hanami/utils/hash'
 
 describe Hanami::Utils::Hash do
@@ -181,7 +182,11 @@ describe Hanami::Utils::Hash do
       ).freeze
 
       exception = -> { hash[:a].push(4) }.must_raise(RuntimeError)
-      exception.message.must_equal "can't modify frozen Array"
+      if Hanami::Utils.jruby?
+        exception.message.must_equal "can't modify frozen array"
+      else
+        exception.message.must_equal "can't modify frozen Array"
+      end
 
       exception = -> { hash[:hash].merge!(foo: 'bar') }.must_raise(RuntimeError)
       exception.message.must_equal "can't modify frozen Hash"

--- a/test/isolation/events/without_concurrent_ruby_test.rb
+++ b/test/isolation/events/without_concurrent_ruby_test.rb
@@ -1,0 +1,19 @@
+require 'rubygems'
+require 'bundler'
+Bundler.require(:default)
+
+require 'minitest'
+require 'minitest/autorun'
+$LOAD_PATH.unshift 'lib'
+
+describe 'Hanami::Events' do
+  describe 'without concurrent-ruby' do
+    it 'raises error' do
+      exception = lambda do
+        require 'hanami/events'
+      end.must_raise(RuntimeError)
+
+      exception.message.must_equal "Cannot find `concurrent-ruby' gem, please install it and retry."
+    end
+  end
+end


### PR DESCRIPTION
## Basic events framework for Hanami
### Usage
#### Subscribe With A Proc

``` ruby
require 'concurrent'
require 'hanami/events'
require 'ostruct'

Hanami::Events.subscribe('signup') do |event|
  puts "New signup: #{event[:user].email}"
end

user = OpenStruct.new(id: 1, email: "user@hanamirb.org")
Hanami::Events.broadcast('signup', user: user)

  # => "New signup: user@hanamirb.org
```
#### Subscribe With An object

``` ruby
require 'concurrent'
require 'hanami/events'
require 'ostruct'

class WelcomeMailer
  def call(event)
    puts "New welcome message for: #{event[:user].email}"
  end
end

Hanami::Events.subscribe('signup', WelcomeMailer.new)

user = OpenStruct.new(id: 1, email: "user@hanamirb.org")
Hanami::Events.broadcast('signup', user: user)

  # => "New welcome message for: user@hanamirb.org
```
#### Include Mixin

``` ruby
require 'concurrent'
require 'hanami/events'
require 'ostruct'

class Signup
  include Hanami::Events

  def call(params)
    user = OpenStruct.new(params)
    broadcast('signup', user: user)
  end
end

Hanami::Events.subscribe('signup') do |event|
  puts "New signup: #{event[:user].email}"
end

Signup.new.call(email: "user@hanamirb.org")
  # => "New signup: user@hanamirb.org
```

---
### Useful for

This can be useful for:
- Automatic logging https://github.com/hanami/hanami/issues/484
- Move mailers to apps https://github.com/hanami/hanami/issues/648
- Async/distributed jobs
#### Automatic Logging

All the Hanami frameworks can broadcast events for operations that we want to automatically log. Things like action response, rendered templates/layouts, database queries/commands. The logger can subscribe to these events and emit a new entry.
#### Move mailers to apps

See https://github.com/hanami/hanami/issues/648#issuecomment-253855250
#### Async/Distributed Jobs

The proposed implementation ships with a memory backend as dispatcher for the events. Which is fine for basic setups, but it has the downside of being volatile.

In the future, third-party devs can implement a backend for async/distributed mechanisms like Sidekiq or Apache Kafka.

---

@hanami/core-team @hanami/contributors Please review. 💚 
