### PR TITLE
Introducing `Hanami::Utils.require!`

### DIFF
--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -1,6 +1,10 @@
-require 'hanami/utils/version'
-
+# Hanami - The web, with simplicity
+#
+# @since 0.1.0
 module Hanami
+  require 'hanami/utils/version'
+  require 'hanami/utils/file_list'
+
   # Ruby core extentions and Hanami utilities
   #
   # @since 0.1.0
@@ -31,6 +35,25 @@ module Hanami
     # @api private
     def self.rubinius?
       RUBY_ENGINE == HANAMI_RUBINIUS
+    end
+
+    # Recursively require Ruby files under the given directory.
+    #
+    # If the directory is relative, it implies it's the path from current directory.
+    # If the directory is absolute, it uses as it is.
+    #
+    # It respects file separator of the current operating system.
+    # A pattern like <tt>"path/to/files"</tt> will work both on *NIX and Windows machines.
+    #
+    # @param [String, Pathname] the directory
+    #
+    # @since x.x.x
+    def self.require!(directory)
+      directory = directory.to_s.gsub(%r{(\/|\\)}, File::SEPARATOR)
+      directory = Pathname.new(Dir.pwd).join(directory).to_s
+      directory = File.join(directory, '**', '*.rb') unless directory =~ /(\*\*)/
+
+      FileList[directory].each { |file| require_relative file }
     end
   end
 end

--- a/test/fixtures/file_list/a.rb
+++ b/test/fixtures/file_list/a.rb
@@ -1,1 +1,2 @@
-# a
+class A
+end

--- a/test/fixtures/file_list/aa.rb
+++ b/test/fixtures/file_list/aa.rb
@@ -1,1 +1,2 @@
-# aa
+class Aa
+end

--- a/test/fixtures/file_list/ab.rb
+++ b/test/fixtures/file_list/ab.rb
@@ -1,1 +1,2 @@
-# ab
+class Ab
+end

--- a/test/fixtures/file_list/nested/c.rb
+++ b/test/fixtures/file_list/nested/c.rb
@@ -1,0 +1,2 @@
+class C
+end

--- a/test/isolation/require/with_absolute_path_test.rb
+++ b/test/isolation/require/with_absolute_path_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'hanami/utils'
+
+describe 'Hanami::Utils.require!' do
+  describe 'with absolute path' do
+    it 'requires ordered set of files' do
+      directory = Pathname.new(Dir.pwd).join('test', 'fixtures', 'file_list')
+      Hanami::Utils.require!(directory)
+
+      assert defined?(A),  'expected A to be defined'
+      assert defined?(Aa), 'expected Aa to be defined'
+      assert defined?(Ab), 'expected Ab to be defined'
+      assert defined?(C),  'expected C to be defined'
+    end
+  end
+end

--- a/test/isolation/require/with_file_separator_test.rb
+++ b/test/isolation/require/with_file_separator_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'hanami/utils'
+
+describe 'Hanami::Utils.require!' do
+  describe 'with file separator' do
+    it 'applies current operating system file separator' do
+      # Invert the file separator for the current operating system:
+      #
+      #   * on *NIX systems, instead of having /, we get \
+      #   * on Windows systems, instead of having \, we get /
+      separator = File::SEPARATOR == '/' ? '\\' : '/'
+      directory = %w(test fixtures file_list).join(separator)
+      Hanami::Utils.require!(directory)
+
+      assert defined?(A),  'expected A to be defined'
+      assert defined?(Aa), 'expected Aa to be defined'
+      assert defined?(Ab), 'expected Ab to be defined'
+      assert defined?(C),  'expected C to be defined'
+    end
+  end
+end

--- a/test/isolation/require/with_recursive_pattern_test.rb
+++ b/test/isolation/require/with_recursive_pattern_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'hanami/utils'
+
+describe 'Hanami::Utils.require!' do
+  describe 'with file separator' do
+    it 'requires ordered set of files' do
+      directory = %w(test fixtures file_list ** *.rb).join(File::SEPARATOR)
+      Hanami::Utils.require!(directory)
+
+      assert defined?(A),  'expected A to be defined'
+      assert defined?(Aa), 'expected Aa to be defined'
+      assert defined?(Ab), 'expected Ab to be defined'
+      assert defined?(C),  'expected C to be defined'
+    end
+  end
+end

--- a/test/isolation/require/with_relative_path_test.rb
+++ b/test/isolation/require/with_relative_path_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'hanami/utils'
+
+describe 'Hanami::Utils.require!' do
+  describe 'with relative path' do
+    it 'requires ordered set of files' do
+      directory = Pathname.new('test').join('fixtures', 'file_list')
+      Hanami::Utils.require!(directory)
+
+      assert defined?(A),  'expected A to be defined'
+      assert defined?(Aa), 'expected Aa to be defined'
+      assert defined?(Ab), 'expected Ab to be defined'
+      assert defined?(C),  'expected C to be defined'
+    end
+  end
+end


### PR DESCRIPTION
A cross-platform, ordered, recursive way to require Ruby files.