### PR TITLE
Allow dasherized routes

### DIFF
--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -72,6 +72,12 @@ module Hanami
       # @api private
       CLASSIFY_WORD_SEPARATOR = /#{CLASSIFY_SEPARATOR}|#{NAMESPACE_SEPARATOR}|#{UNDERSCORE_SEPARATOR}|#{DASHERIZE_SEPARATOR}/
 
+      # Regexp for #classify
+      #
+      # @since 0.9.0
+      # @api private
+      CLASSIFY_DELIMITER_REGEXP = /#{CLASSIFY_SEPARATOR}|#{DASHERIZE_SEPARATOR}/
+
       # Initialize the string
       #
       # @param string [::String, Symbol] the value we want to initialize
@@ -145,7 +151,7 @@ module Hanami
         delimiters = scan(CLASSIFY_WORD_SEPARATOR)
 
         delimiters.map! do |delimiter|
-          delimiter == CLASSIFY_SEPARATOR ? EMPTY_STRING : NAMESPACE_SEPARATOR
+          CLASSIFY_DELIMITER_REGEXP =~ delimiter ? EMPTY_STRING : NAMESPACE_SEPARATOR
         end
 
         self.class.new words.zip(delimiters).join

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -66,7 +66,7 @@ describe Hanami::Utils::String do
     it 'returns a classified string' do
       Hanami::Utils::String.new('hanami').classify.must_equal('Hanami')
       Hanami::Utils::String.new('hanami_router').classify.must_equal('HanamiRouter')
-      Hanami::Utils::String.new('hanami-router').classify.must_equal('Hanami::Router')
+      Hanami::Utils::String.new('hanami-router').classify.must_equal('HanamiRouter')
       Hanami::Utils::String.new('hanami/router').classify.must_equal('Hanami::Router')
       Hanami::Utils::String.new('hanami::router').classify.must_equal('Hanami::Router')
       Hanami::Utils::String.new('hanami::router/base_object').classify.must_equal('Hanami::Router::BaseObject')
@@ -75,7 +75,7 @@ describe Hanami::Utils::String do
     it 'returns a classified string from symbol' do
       Hanami::Utils::String.new(:hanami).classify.must_equal('Hanami')
       Hanami::Utils::String.new(:hanami_router).classify.must_equal('HanamiRouter')
-      Hanami::Utils::String.new(:'hanami-router').classify.must_equal('Hanami::Router')
+      Hanami::Utils::String.new(:'hanami-router').classify.must_equal('HanamiRouter')
       Hanami::Utils::String.new(:'hanami/router').classify.must_equal('Hanami::Router')
       Hanami::Utils::String.new(:'hanami::router').classify.must_equal('Hanami::Router')
     end


### PR DESCRIPTION
When working with an API project following [JSON:API conventions](http://jsonapi.org/recommendations/), the common word separator is `-` (names and route segments are dasherized).

I'm very new to the Hanami codebase but it seems that routes are resolved to a controller in part via `Hanami::Utils::String#classify`. Currently that method treats any delimiter other than `_` as a namespace separator so `'test-resource'` becomes `Test::Resource` rather than `TestResource` which is awkward for naming and directory structure.

This change allows dasherized routes e.g. "test-resource" to behave like "test_resource".

Before this change dasherized routes resolve like:
```
'test-resource' => Web::Controllers::Test::Resource
'test_resource' => Web::Controllers::TestResource
```

After this change dasherized routes resolve like underscored routes:
```
'test-resource' => Web::Controllers::TestResource
'test_resource' => Web::Controllers::TestResource
```

In my testing so far this doesn't seem to cause any problems with my existing API app. I don't know if there is a larger Hanami integration test suite I should run this change against.