### PR TITLE
Introduced `Hanami::Utils::Json.parse` for safe JSON parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Hanami::Utils
 Ruby core extentions and class utilities for Hanami
 
+## v0.9.1 - 2016-11-18
+### Added
+- [Luca Guidi] Introduced `Utils::Json.parse` and `.generate`
+
+### Fixed
+- [Luca Guidi] Ensure `Utils::Json` parsing to not eval untrusted input
+
+### Changed
+- [Luca Guidi] Deprecated `Utils::Json.load` in favor of `.parse`
+- [Luca Guidi] Deprecated `Utils::Json.dump` in favor of `.generate`
+
 ## v0.9.0 - 2016-11-15
 ### Added
 – [Luca Guidi] Introduced `Utils.require!` to recursively require Ruby files with an order that is consistent across platforms

--- a/lib/hanami/utils/json.rb
+++ b/lib/hanami/utils/json.rb
@@ -4,6 +4,8 @@ rescue LoadError
   require 'json'
 end
 
+require 'hanami/utils/deprecation'
+
 module Hanami
   module Utils
     # JSON wrapper
@@ -13,9 +15,33 @@ module Hanami
     #
     # @since 0.8.0
     module Json
+      # MultiJson adapter
+      #
+      # @since 0.9.1
+      # @api private
+      class MultiJsonAdapter
+        # @since 0.9.1
+        # @api private
+        def parse(payload)
+          MultiJson.load(payload)
+        end
+
+        # FIXME: remove this alias, when Hanami::Utils::Json.load will be removed
+        #
+        # @since 0.9.1
+        # @api private
+        alias load parse
+
+        # @since 0.9.1
+        # @api private
+        def dump(object)
+          MultiJson.dump(object)
+        end
+      end
+
       # rubocop:disable Style/ClassVars
       if defined?(MultiJson)
-        @@engine    = MultiJson
+        @@engine    = MultiJsonAdapter.new
         ParserError = MultiJson::ParseError
       else
         @@engine    = ::JSON
@@ -32,8 +58,24 @@ module Hanami
       # @raise [Hanami::Utils::Json::ParserError] if the paylod is invalid
       #
       # @since 0.8.0
+      #
+      # @deprecated Use {#parse} instead
       def self.load(payload)
+        Hanami::Utils::Deprecation.new("`Hanami::Utils::Json.load' is deprecated, please use `Hanami::Utils::Json.parse'")
         @@engine.load(payload)
+      end
+
+      # Parse the given JSON paylod
+      #
+      # @param payload [String] a JSON payload
+      #
+      # @return [Object] the result of the loading process
+      #
+      # @raise [Hanami::Utils::Json::ParserError] if the paylod is invalid
+      #
+      # @since 0.9.1
+      def self.parse(payload)
+        @@engine.parse(payload)
       end
 
       # Dump the given object into a JSON payload

--- a/lib/hanami/utils/json.rb
+++ b/lib/hanami/utils/json.rb
@@ -32,9 +32,17 @@ module Hanami
         # @api private
         alias load parse
 
+        # FIXME: remove this method, when Hanami::Utils::Json.dump will be removed
+        #
         # @since 0.9.1
         # @api private
         def dump(object)
+          generate(object)
+        end
+
+        # @since 0.9.1
+        # @api private
+        def generate(object)
           MultiJson.dump(object)
         end
       end
@@ -59,7 +67,7 @@ module Hanami
       #
       # @since 0.8.0
       #
-      # @deprecated Use {#parse} instead
+      # @deprecated Use {.parse} instead
       def self.load(payload)
         Hanami::Utils::Deprecation.new("`Hanami::Utils::Json.load' is deprecated, please use `Hanami::Utils::Json.parse'")
         @@engine.load(payload)
@@ -85,8 +93,22 @@ module Hanami
       # @return [String] the result of the dumping process
       #
       # @since 0.8.0
+      #
+      # @deprecated Use {.generate} instead
       def self.dump(object)
+        Hanami::Utils::Deprecation.new("`Hanami::Utils::Json.dump' is deprecated, please use `Hanami::Utils::Json.generate'")
         @@engine.dump(object)
+      end
+
+      # Generate a JSON document from the given object
+      #
+      # @param object [Object] any object
+      #
+      # @return [String] the result of the dumping process
+      #
+      # @since 0.9.1
+      def self.generate(object)
+        @@engine.generate(object)
       end
     end
   end

--- a/lib/hanami/utils/version.rb
+++ b/lib/hanami/utils/version.rb
@@ -3,6 +3,6 @@ module Hanami
     # Defines the version
     #
     # @since 0.1.0
-    VERSION = '0.9.0'.freeze
+    VERSION = '0.9.1'.freeze
   end
 end

--- a/test/isolation/json/json_test.rb
+++ b/test/isolation/json/json_test.rb
@@ -56,8 +56,18 @@ describe Hanami::Utils::Json do
 
     describe '.dump' do
       it 'dumps given Hash' do
-        actual = Hanami::Utils::Json.dump(a: 1)
-        actual.must_equal %({"a":1})
+        capture_io do
+          actual = Hanami::Utils::Json.dump(a: 1)
+          actual.must_equal %({"a":1})
+        end
+      end
+
+      it 'is deprecated' do
+        _, err = capture_io do
+          Hanami::Utils::Json.dump(a: 1)
+        end
+
+        err.must_include "`Hanami::Utils::Json.dump' is deprecated, please use `Hanami::Utils::Json.generate'"
       end
     end
   end

--- a/test/isolation/json/json_test.rb
+++ b/test/isolation/json/json_test.rb
@@ -16,12 +16,41 @@ describe Hanami::Utils::Json do
 
     describe '.load' do
       it 'loads given payload' do
-        actual = Hanami::Utils::Json.load %({"a":1})
+        capture_io do
+          actual = Hanami::Utils::Json.load %({"a":1})
+          actual.must_equal('a' => 1)
+        end
+      end
+
+      it 'raises error if given payload is malformed' do
+        capture_io do
+          -> { Hanami::Utils::Json.load %({"a:1}) }.must_raise(Hanami::Utils::Json::ParserError)
+        end
+      end
+
+      it 'is deprecated' do
+        _, err = capture_io do
+          Hanami::Utils::Json.load %({"a":1})
+        end
+
+        err.must_include "`Hanami::Utils::Json.load' is deprecated, please use `Hanami::Utils::Json.parse'"
+      end
+    end
+
+    describe '.parse' do
+      it 'loads given payload' do
+        actual = Hanami::Utils::Json.parse %({"a":1})
         actual.must_equal('a' => 1)
       end
 
       it 'raises error if given payload is malformed' do
-        -> { Hanami::Utils::Json.load %({"a:1}) }.must_raise(Hanami::Utils::Json::ParserError)
+        -> { Hanami::Utils::Json.parse %({"a:1}) }.must_raise(Hanami::Utils::Json::ParserError)
+      end
+
+      # See: https://github.com/hanami/utils/issues/169
+      it "doesn't eval payload" do
+        actual = Hanami::Utils::Json.parse %({"json_class": "Foo"})
+        actual.must_equal('json_class' => 'Foo')
       end
     end
 

--- a/test/isolation/json/multi_json_test.rb
+++ b/test/isolation/json/multi_json_test.rb
@@ -56,7 +56,24 @@ describe Hanami::Utils::Json do
 
     describe '.dump' do
       it 'dumps given Hash' do
-        actual = Hanami::Utils::Json.dump(a: 1)
+        capture_io do
+          actual = Hanami::Utils::Json.dump(a: 1)
+          actual.must_equal %({"a":1})
+        end
+      end
+
+      it 'is deprecated' do
+        _, err = capture_io do
+          Hanami::Utils::Json.dump(a: 1)
+        end
+
+        err.must_include "`Hanami::Utils::Json.dump' is deprecated, please use `Hanami::Utils::Json.generate'"
+      end
+    end
+
+    describe '.generate' do
+      it 'dumps given Hash' do
+        actual = Hanami::Utils::Json.generate(a: 1)
         actual.must_equal %({"a":1})
       end
     end

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe Hanami::Utils::VERSION do
   it 'exposes version' do
-    Hanami::Utils::VERSION.must_equal '0.9.0'
+    Hanami::Utils::VERSION.must_equal '0.9.1'
   end
 end


### PR DESCRIPTION
Introduced `Hanami::Utils::Json.parse` for safe JSON parsing.
Deprecate `Hanami::Utils::Json.load` in favor of `.parse`.

Introduced `Hanami::Utils::Json.generate` for safer JSON generation.
Deprecate `Hanami::Utils::Json.dump` in favor of `.generate`.

---

Closes #169 

/cc @AlfonsoUceda @beauby 