### PR TITLE
Pluralize -en to -ens instead of -ina

### DIFF
--- a/lib/hanami/utils/inflector.rb
+++ b/lib/hanami/utils/inflector.rb
@@ -93,10 +93,6 @@ module Hanami
 
       # @since 0.4.1
       # @api private
-      INA  = 'ina'.freeze
-
-      # @since 0.4.1
-      # @api private
       IS   = 'is'.freeze
 
       # @since 0.4.1
@@ -373,8 +369,6 @@ module Hanami
           $1 + A
         when /\A(buffal|domin|ech|embarg|her|mosquit|potat|tomat)#{ O }\z/i
           $1 + OES
-        when /\A(.*)(en|#{ INA })\z/
-          $1 + INA
         when /\A(.*)(?:([^f]))f[e]*\z/
           $1 + $2 + VES
         when /\A(.*)us\z/

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -354,10 +354,6 @@ TEST_PLURALS = {
   'tomato'   => 'tomatoes',
   'torpedo'  => 'torpedos',
   'veto'     => 'vetos',
-  # en => ina
-  'stamen'  => 'stamina',
-  'foramen' => 'foramina',
-  'lumen'   => 'lumina',
   # a => ata
   'anathema'  => 'anathemata',
   'enema'     => 'enemata',
@@ -543,7 +539,9 @@ TEST_PLURALS = {
   'car'          => 'cars',
   'hive'         => 'hives',
   # https://github.com/hanami/utils/issues/106
-  'album'        => 'albums'
+  'album'        => 'albums',
+  # https://github.com/hanami/utils/issues/173
+  'kitten'       => 'kittens'
 }.freeze
 
 TEST_SINGULARS = {
@@ -572,6 +570,10 @@ TEST_SINGULARS = {
   # f => s
   'chief' => 'chiefs',
   'spoof' => 'spoofs',
+  # en => ina
+  'stamen'  => 'stamina',
+  'foramen' => 'foramina',
+  'lumen'   => 'lumina',
   # s => es
   'acropolis'  => 'acropolises',
   'chaos'      => 'chaoses',


### PR DESCRIPTION
Plural rules with adding -s instead of changing ending to -ina are considered to be correct (i.e. "stamens" instead of "stamina") and do not create false plural forms of common English words, such as "kitten". They are still correctly singularized, though.

See: https://github.com/hanami/utils/issues/173