### PR TITLE
Add Gitter webhook to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,11 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/82dbf42817b3b6d06aca
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start:   never   # options: [always|never|change] default: always


### PR DESCRIPTION
So we can get updates in Gitter when builds fail.

cc @AlfonsoUceda 