### PR TITLE
Improve logger

### DIFF
--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -108,10 +108,6 @@ module Hanami
       # @api private
       NEW_LINE = $/
 
-      # @since x.x.x
-      # @api private
-      TIME_RFC3339_FORMAT = "%FT%T%:z".freeze
-
       include Utils::ClassAttribute
 
       class_attribute :subclasses
@@ -149,7 +145,7 @@ module Hanami
         _format({
           app:      @application_name,
           severity: severity,
-          time:     time.utc.strftime(TIME_RFC3339_FORMAT)
+          time:     time
         }.merge(
           _message_hash(msg)
         ))
@@ -202,6 +198,7 @@ module Hanami
       # @since 0.8.0
       # @api private
       def _format(hash)
+        hash[:time] = hash[:time].utc.iso8601
         Hanami::Utils::Json.dump(hash)
       end
     end
@@ -211,7 +208,7 @@ module Hanami
     #
     # @since 0.5.0
     # @api private
-    DEFAULT_APPLICATION_NAME = 'Hanami'.freeze
+    DEFAULT_APPLICATION_NAME = 'hanami'.freeze
 
     # @since 0.8.0
     # @api private

--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -159,10 +159,8 @@ module Hanami
 
       # @since 0.8.0
       # @api private
-      def _message_hash(message) # rubocop:disable Metrics/MethodLength
+      def _message_hash(message)
         case message
-        when Hash
-          message
         when Exception
           Hash[
             message:   message.message,
@@ -174,10 +172,18 @@ module Hanami
         end
       end
 
-      # @since 0.8.0
+      # @since x.x.x
       # @api private
       def _format(hash)
-        hash.map { |k, v| "#{k}=#{v}" }.join(SEPARATOR) + NEW_LINE
+        format = "[#{hash[:app]}] [#{hash[:severity]}] [#{hash[:time]}]"
+        format << " #{hash[:error]}:" if hash.key?(:error)
+        format << " #{hash[:message]}#{NEW_LINE}"
+        if hash.key?(:backtrace)
+          hash[:backtrace].each do |line|
+            format << "from #{line}#{NEW_LINE}"
+          end
+        end
+        format
       end
     end
 

--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -108,6 +108,10 @@ module Hanami
       # @api private
       NEW_LINE = $/
 
+      # @since x.x.x
+      # @api private
+      TIME_RFC3339_FORMAT = "%FT%T%:z".freeze
+
       include Utils::ClassAttribute
 
       class_attribute :subclasses
@@ -145,7 +149,7 @@ module Hanami
         _format({
           app:      @application_name,
           severity: severity,
-          time:     time.utc
+          time:     time.utc.strftime(TIME_RFC3339_FORMAT)
         }.merge(
           _message_hash(msg)
         ))

--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -168,7 +168,7 @@ module Hanami
         end
       end
 
-      # @since x.x.x
+      # @since 0.8.0
       # @api private
       def _format(hash)
         format = "[#{hash[:app]}] [#{hash[:severity]}] [#{hash[:time]}]"

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -274,7 +274,7 @@ describe Hanami::Logger do
 
     it 'has default app tag when not in any namespace' do
       class TestLogger < Hanami::Logger; end
-      TestLogger.new.application_name.must_equal 'Hanami'
+      TestLogger.new.application_name.must_equal 'hanami'
     end
 
     it 'infers apptag from namespace' do
@@ -312,7 +312,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: nil).info('foo')
             end
-          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] foo\n"
+          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] foo\n"
         end
       end
     end
@@ -328,7 +328,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: :json).info('foo')
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":"foo"}'
+            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":"foo"}'
           end
         end
       end
@@ -343,7 +343,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info('foo')
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":"foo"}'
+            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":"foo"}'
           end
         end
       end
@@ -358,7 +358,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).error(Exception.new('foo'))
               end
-            output.must_equal '{"app":"Hanami","severity":"ERROR","time":"1988-09-01T00:00:00+00:00","message":"foo","backtrace":[],"error":"Exception"}'
+            output.must_equal '{"app":"hanami","severity":"ERROR","time":"2017-01-15T15:00:23Z","message":"foo","backtrace":[],"error":"Exception"}'
           end
         end
       end
@@ -373,7 +373,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(foo: :bar)
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":{"foo":"bar"}}'
+            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":{"foo":"bar"}}'
           end
         end
       end
@@ -388,7 +388,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(['foo'])
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":["foo"]}'
+            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":["foo"]}'
           end
         end
       end
@@ -402,7 +402,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: :default).info('foo')
             end
-          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] foo\n"
+          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] foo\n"
         end
       end
 
@@ -413,7 +413,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info('foo')
             end
-          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] foo\n"
+          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] foo\n"
         end
       end
 
@@ -429,7 +429,7 @@ describe Hanami::Logger do
             end
             TestLogger.new.error(exception)
           end
-          expectation = "[Hanami] [ERROR] [1988-09-01T00:00:00+00:00] StandardError: foo\n"
+          expectation = "[hanami] [ERROR] [2017-01-15 16:00:23 +0100] StandardError: foo\n"
           exception.backtrace.each do |line|
             expectation << "from #{line}\n"
           end
@@ -444,7 +444,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(foo: :bar)
             end
-          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] {:foo=>:bar}\n"
+          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] {:foo=>:bar}\n"
         end
       end
 
@@ -455,7 +455,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(['foo'])
             end
-          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] [\"foo\"]\n"
+          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] [\"foo\"]\n"
         end
       end
     end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -312,7 +312,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: nil).info('foo')
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01 00:00:00 UTC message=foo\n"
+          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=foo\n"
         end
       end
     end
@@ -328,7 +328,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: :json).info('foo')
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01 00:00:00 UTC","message":"foo"}'
+            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":"foo"}'
           end
         end
       end
@@ -343,7 +343,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info('foo')
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01 00:00:00 UTC","message":"foo"}'
+            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":"foo"}'
           end
         end
       end
@@ -358,7 +358,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).error(Exception.new('foo'))
               end
-            output.must_equal '{"app":"Hanami","severity":"ERROR","time":"1988-09-01 00:00:00 UTC","message":"foo","backtrace":[],"error":"Exception"}'
+            output.must_equal '{"app":"Hanami","severity":"ERROR","time":"1988-09-01T00:00:00+00:00","message":"foo","backtrace":[],"error":"Exception"}'
           end
         end
       end
@@ -373,7 +373,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(foo: :bar)
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01 00:00:00 UTC","foo":"bar"}'
+            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","foo":"bar"}'
           end
         end
       end
@@ -388,7 +388,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(['foo'])
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01 00:00:00 UTC","message":["foo"]}'
+            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":["foo"]}'
           end
         end
       end
@@ -402,7 +402,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: :default).info('foo')
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01 00:00:00 UTC message=foo\n"
+          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=foo\n"
         end
       end
 
@@ -413,7 +413,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info('foo')
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01 00:00:00 UTC message=foo\n"
+          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=foo\n"
         end
       end
 
@@ -424,7 +424,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.error(Exception.new('foo'))
             end
-          output.must_equal "app=Hanami severity=ERROR time=1988-09-01 00:00:00 UTC message=foo backtrace=[] error=Exception\n"
+          output.must_equal "app=Hanami severity=ERROR time=1988-09-01T00:00:00+00:00 message=foo backtrace=[] error=Exception\n"
         end
       end
 
@@ -435,7 +435,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(foo: :bar)
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01 00:00:00 UTC foo=bar\n"
+          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 foo=bar\n"
         end
       end
 
@@ -446,7 +446,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(['foo'])
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01 00:00:00 UTC message=[\"foo\"]\n"
+          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=[\"foo\"]\n"
         end
       end
     end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -312,7 +312,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: nil).info('foo')
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=foo\n"
+          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] foo\n"
         end
       end
     end
@@ -373,7 +373,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(foo: :bar)
               end
-            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","foo":"bar"}'
+            output.must_equal '{"app":"Hanami","severity":"INFO","time":"1988-09-01T00:00:00+00:00","message":{"foo":"bar"}}'
           end
         end
       end
@@ -402,7 +402,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: :default).info('foo')
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=foo\n"
+          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] foo\n"
         end
       end
 
@@ -413,18 +413,27 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info('foo')
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=foo\n"
+          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] foo\n"
         end
       end
 
       it 'has key=value format for error messages' do
         stub_time_now do
-          output =
-            stub_stdout_constant do
-              class TestLogger < Hanami::Logger; end
-              TestLogger.new.error(Exception.new('foo'))
+          exception = nil
+          output = stub_stdout_constant do
+            class TestLogger < Hanami::Logger; end
+            begin
+              raise StandardError.new('foo')
+            rescue => e
+              exception = e
             end
-          output.must_equal "app=Hanami severity=ERROR time=1988-09-01T00:00:00+00:00 message=foo backtrace=[] error=Exception\n"
+            TestLogger.new.error(exception)
+          end
+          expectation = "[Hanami] [ERROR] [1988-09-01T00:00:00+00:00] StandardError: foo\n"
+          exception.backtrace.each do |line|
+            expectation << "from #{line}\n"
+          end
+          output.must_equal expectation
         end
       end
 
@@ -435,7 +444,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(foo: :bar)
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 foo=bar\n"
+          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] {:foo=>:bar}\n"
         end
       end
 
@@ -446,7 +455,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(['foo'])
             end
-          output.must_equal "app=Hanami severity=INFO time=1988-09-01T00:00:00+00:00 message=[\"foo\"]\n"
+          output.must_equal "[Hanami] [INFO] [1988-09-01T00:00:00+00:00] [\"foo\"]\n"
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'bundler/setup'
+require 'time'
 
 if ENV['COVERALL']
   require 'coveralls'
@@ -41,7 +42,7 @@ def stub_stdout_constant # rubocop:disable Metrics/MethodLength
 end
 
 def stub_time_now
-  Time.stub :now, Time.utc(1988, 9, 1, 0, 0, 0) do
+  Time.stub :now, Time.parse("2017-01-15 16:00:23 +0100") do
     yield
   end
 end


### PR DESCRIPTION
Talking with @jodosha I saw this example log for default formatter in hanami logger:
```
app=hanami.model severity=INFO time=2017-01-03 17:17:17 UTC message=(0.000260s) SELECT `id`, `name`, `created_at`, `updated_at` FROM `authors` WHERE (`id` IN (1)) ORDER BY `authors`.`id`
```
This kind of log, will break with integrations like logstash, if your value has spaces, then it should be wrapped between quotes. (I'm using single quotes).

For time, I'm using RFC 3339 in UTC without spaces.

The result of the previous log would be:
```
app=hanami.model severity=INFO time=2017-01-03T17:17:17+00:00 message='(0.000260s) SELECT `id`, `name`, `created_at`, `updated_at` FROM `authors` WHERE (`id` IN (1)) ORDER BY `authors`.`id`'
```

cc @hanami/contributors @hanami/core