### PR TITLE
`Hanami::Utils.reload!`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_from:
 Metrics/BlockLength:
   Exclude:
     - 'test/**/*'
+    - 'tmp/**/*'
 Style/DoubleNegation:
   Enabled: false
 Style/SpecialGlobalVars:

--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -52,10 +52,36 @@ module Hanami
       for_each_file_in(directory) { |file| require_relative(file) }
     end
 
+    # Recursively reload Ruby files under the given directory.
+    #
+    # If the directory is relative, it implies it's the path from current directory.
+    # If the directory is absolute, it uses as it is.
+    #
+    # It respects file separator of the current operating system.
+    # A pattern like <tt>"path/to/files"</tt> will work both on *NIX and Windows machines.
+    #
+    # @param directory [String, Pathname] the directory
+    #
+    # @since x.x.x
+    # @api private
     def self.reload!(directory)
       for_each_file_in(directory) { |file| load(file) }
     end
 
+    # Recursively scans through the given directory and yields the given block
+    # for each Ruby source file.
+    #
+    # If the directory is relative, it implies it's the path from current directory.
+    # If the directory is absolute, it uses as it is.
+    #
+    # It respects file separator of the current operating system.
+    # A pattern like <tt>"path/to/files"</tt> will work both on *NIX and Windows machines.
+    #
+    # @param directory [String, Pathname] the directory
+    # @param blk [Proc] the block to yield
+    #
+    # @since x.x.x
+    # @api private
     def self.for_each_file_in(directory, &blk)
       directory = directory.to_s.gsub(%r{(\/|\\)}, File::SEPARATOR)
       directory = Pathname.new(Dir.pwd).join(directory).to_s

--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -49,11 +49,19 @@ module Hanami
     #
     # @since 0.9.0
     def self.require!(directory)
+      for_each_file_in(directory) { |file| require_relative(file) }
+    end
+
+    def self.reload!(directory)
+      for_each_file_in(directory) { |file| load(file) }
+    end
+
+    def self.for_each_file_in(directory, &blk)
       directory = directory.to_s.gsub(%r{(\/|\\)}, File::SEPARATOR)
       directory = Pathname.new(Dir.pwd).join(directory).to_s
       directory = File.join(directory, '**', '*.rb') unless directory =~ /(\*\*)/
 
-      FileList[directory].each { |file| require_relative file }
+      FileList[directory].each(&blk)
     end
   end
 end

--- a/test/isolation/reload_test.rb
+++ b/test/isolation/reload_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+require 'hanami/utils'
+require 'pathname'
+
+describe 'Hanami::Utils.reload!' do
+  before do
+    FileUtils.rm_rf(root) if root.exist?
+    root.mkpath
+  end
+
+  after do
+    FileUtils.rm_rf(root.parent)
+  end
+
+  let(:root) { Pathname.new(Dir.pwd).join('tmp', 'reload') }
+
+  it 'reloads the files set of files' do
+    File.open(root.join('user.rb'), 'w+') do |f|
+      f.write <<-EOF
+class User
+  def greet
+    "Hi"
+  end
+end
+EOF
+    end
+
+    Hanami::Utils.reload!(root)
+    User.new.greet.must_equal "Hi"
+
+    File.open(root.join('user.rb'), 'w+') do |f|
+      f.write <<-EOF
+class User
+  def greet
+    "Ciao"
+  end
+end
+EOF
+    end
+
+    Hanami::Utils.reload!(root)
+    User.new.greet.must_equal "Ciao"
+  end
+end


### PR DESCRIPTION
This is a proposal to add an API to recursively reload Ruby code for a given directory.

This is related to https://github.com/hanami/hanami/issues/702.
The way code reloading working for Hanami 0.9 is to use Shotgun as a mechanism to reload the code.

Shotgun works fine for all the Rack applications in a project, but not for other code outside of them.
For a Hanami project `apps/` gets reloaded, but `lib/` doesn't.

This PR introduces a mechanism to force code reloading via `Kernel.load`. When a file was already required, in order to reload it's content, loading it will refresh the code the Ruby VM.

**Please note** that this new `Hanami::Utils` feature will be used in Hanami projects only for `lib/`.

/cc @hanami/ecosystem @hanami/issues for review.