### PR TITLE
Logger hash message

### DIFF
--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -137,13 +137,17 @@ module Hanami
       # @api private
       attr_writer :application_name
 
+      # @since x.x.x
+      # @api private
+      attr_reader :application_name
+
       # @since 0.5.0
       # @api private
       #
       # @see http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger/Formatter.html#method-i-call
       def call(severity, time, _progname, msg)
         _format({
-          app:      @application_name,
+          app:      application_name,
           severity: severity,
           time:     time
         }.merge(

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -328,7 +328,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: :json).info('foo')
               end
-            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":"foo"}'
+            output.must_equal %({"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":"foo"}\n)
           end
         end
       end
@@ -343,7 +343,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info('foo')
               end
-            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":"foo"}'
+            output.must_equal %({"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":"foo"}\n)
           end
         end
       end
@@ -358,7 +358,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).error(Exception.new('foo'))
               end
-            output.must_equal '{"app":"hanami","severity":"ERROR","time":"2017-01-15T15:00:23Z","message":"foo","backtrace":[],"error":"Exception"}'
+            output.must_equal %({"app":"hanami","severity":"ERROR","time":"2017-01-15T15:00:23Z","message":"foo","backtrace":[],"error":"Exception"}\n)
           end
         end
       end
@@ -373,7 +373,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(foo: :bar)
               end
-            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":{"foo":"bar"}}'
+            output.must_equal %({"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","foo":"bar"}\n)
           end
         end
       end
@@ -388,7 +388,7 @@ describe Hanami::Logger do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(['foo'])
               end
-            output.must_equal '{"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":["foo"]}'
+            output.must_equal %({"app":"hanami","severity":"INFO","time":"2017-01-15T15:00:23Z","message":["foo"]}\n)
           end
         end
       end
@@ -444,7 +444,7 @@ describe Hanami::Logger do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(foo: :bar)
             end
-          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] {:foo=>:bar}\n"
+          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] bar\n"
         end
       end
 
@@ -453,9 +453,9 @@ describe Hanami::Logger do
           output =
             stub_stdout_constant do
               class TestLogger < Hanami::Logger; end
-              TestLogger.new.info(['foo'])
+              TestLogger.new.info(%(foo bar))
             end
-          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] [\"foo\"]\n"
+          output.must_equal "[hanami] [INFO] [2017-01-15 16:00:23 +0100] foo bar\n"
         end
       end
     end


### PR DESCRIPTION
This proposal introduces a small change in the logger. When we pass a Hash, it should print all the key/value pairs instead of wrapping them into `:message` key.

### Default logger

#### Before

```ruby
logger.info(http: "HTTP/1.1", verb: "GET")

  # => [bookshelf] [INFO] [2017-01-31 14:40:13 +0100] {:http=>"HTTP/1.1", :verb=>"GET"}
```

#### After

```ruby
logger.info(http: "HTTP/1.1", verb: "GET")

  # => [bookshelf] [INFO] [2017-01-31 14:40:51 +0100] HTTP/1.1 GET
```

### JSON logger

#### Before

```ruby
logger.info(http: "HTTP/1.1", verb: "GET")

  # => {"app":"bookshelf","severity":"INFO","time":"2017-01-31T13:36:18Z","message":{"http":"HTTP/1.1","verb":"GET"}}
```

#### After

```ruby
logger.info(http: "HTTP/1.1", verb: "GET")

  # => {"app":"bookshelf","severity":"INFO","time":"2017-01-31T13:41:44Z","http":"HTTP/1.1","verb":"GET"}
```

---

/cc @AlfonsoUceda @hanami/issues @hanami/ecosystem for review 👍 