### PR TITLE
Introduce ::filled? method

### DIFF
--- a/lib/hanami/utils/blank.rb
+++ b/lib/hanami/utils/blank.rb
@@ -2,6 +2,7 @@ module Hanami
   module Utils
     # Checks for blank
     # @since 0.8.0
+    # @api private
     class Blank
       # Matcher for blank strings
       #
@@ -26,6 +27,7 @@ module Hanami
       # @return [TrueClass,FalseClass]
       #
       # @since 0.8.0
+      # @api private
       def self.blank?(object) # rubocop:disable Metrics/MethodLength
         case object
         when String, ::String
@@ -39,6 +41,28 @@ module Hanami
         else
           object.respond_to?(:empty?) ? object.empty? : !self
         end
+      end
+
+      # Checks object is filled
+      #
+      # @example Basic Usage
+      #   require 'hanami/utils/blank'
+      #
+      #   Hanami::Utils::Blank.filled?(true)                          # => true
+      #   Hanami::Utils::Blank.filled?(1)                             # => true
+      #   Hanami::Utils::Blank.filled?(Hanami::Utils::String.new('')) # => false
+      #   Hanami::Utils::Blank.filled?('  ')                          # => false
+      #   Hanami::Utils::Blank.filled?(nil)                           # => false
+      #   Hanami::Utils::Blank.filled?(Hanami::Utils::Hash.new({}))   # => false
+      #
+      # @param object the argument
+      #
+      # @return [TrueClass,FalseClass]
+      #
+      # @since x.x.x
+      # @api private
+      def self.filled?(object)
+        !blank?(object)
       end
     end
   end

--- a/test/blank_test.rb
+++ b/test/blank_test.rb
@@ -23,4 +23,22 @@ describe Hanami::Utils::Blank do
        end
      end
   end
+
+  describe '.filled?' do
+    [nil, false, '', '   ', "  \n\t  \r ", '　', "\u00a0", [], {}, Set.new,
+     Hanami::Utils::Kernel.Boolean(0), Hanami::Utils::String.new(''),
+     Hanami::Utils::Hash.new({})].each do |v|
+       it 'returns false' do
+         Hanami::Utils::Blank.filled?(v).must_equal false
+       end
+     end
+
+    [Object.new, true, 0, 1, 'a', :book, DateTime.now, Time.now, Date.new, [nil], { nil => 0 }, Set.new([1]),
+     Hanami::Utils::Kernel.Symbol(:hello), Hanami::Utils::String.new('foo'),
+     Hanami::Utils::Hash.new(foo: :bar)].each do |v|
+       it 'returns true' do
+         Hanami::Utils::Blank.filled?(v).must_equal true
+       end
+     end
+  end
 end


### PR DESCRIPTION
I think it will be helpful to have the antonym for `.blank?` method instead of using `!Hanami::Utils::Blank.blank?(value)`.

WDYT?

/cc @hanami/core @hanami/ecosystem 