### PR TITLE
API docs cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,6 @@ Style/SpecialGlobalVars:
   Enabled: false
 Style/MethodMissing:
   Enabled: false
+Style/MethodName:
+  Exclude:
+    - 'lib/hanami/utils/kernel.rb'

--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -39,12 +39,12 @@ module Hanami
   # And if you want to use custom formatter you need create new class inherited from
   # `Formatter` class and define `_format` private method like this:
   #
-  #   class CustomFormatter < Formatter
-  #     private
-  #     def _format(hash)
-  #       # ...
+  #     class CustomFormatter < Formatter
+  #       private
+  #       def _format(hash)
+  #         # ...
+  #       end
   #     end
-  #   end
   #
   # @since 0.5.0
   #

--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -128,11 +128,13 @@ module Hanami
         end.tap { |f| f.application_name = application_name }
       end
 
+      # @api private
       def self.inherited(subclass)
         super
         subclasses << subclass
       end
 
+      # @api private
       def self.eligible?(name)
         name == :default
       end
@@ -192,6 +194,7 @@ module Hanami
         result
       end
 
+      # @api private
       def _format_error(result, hash)
         result << " #{hash[:error]}:" if hash.key?(:error)
         result << " #{hash[:message]}#{NEW_LINE}"
@@ -211,6 +214,7 @@ module Hanami
     # @since 0.5.0
     # @api private
     class JSONFormatter < Formatter
+      # @api private
       def self.eligible?(name)
         name == :json
       end

--- a/lib/hanami/utils/blank.rb
+++ b/lib/hanami/utils/blank.rb
@@ -1,6 +1,7 @@
 module Hanami
   module Utils
     # Checks for blank
+    #
     # @since 0.8.0
     # @api private
     class Blank

--- a/lib/hanami/utils/callbacks.rb
+++ b/lib/hanami/utils/callbacks.rb
@@ -170,6 +170,7 @@ module Hanami
 
         private
 
+        # @api private
         def callables(callbacks, block)
           callbacks.push(block) if block
           callbacks.map { |c| Factory.fabricate(c) }
@@ -179,7 +180,7 @@ module Hanami
       # Callback factory
       #
       # @since 0.1.0
-      # @private
+      # @api private
       class Factory
         # Instantiates a `Callback` according to if it responds to #call.
         #
@@ -213,8 +214,9 @@ module Hanami
       # It wraps an object that responds to #call
       #
       # @since 0.1.0
-      # @private
+      # @api private
       class Callback
+        # @api private
         attr_reader :callback
 
         # Initialize by wrapping the given callback
@@ -224,7 +226,7 @@ module Hanami
         # @return [Callback] self
         #
         # @since 0.1.0
-        #
+        # @api private
         def initialize(callback)
           @callback = callback
         end
@@ -237,6 +239,7 @@ module Hanami
         # @return [void, Object] It may return a value, it depends on the callback.
         #
         # @since 0.1.0
+        # @api private
         #
         # @see Hanami::Utils::Callbacks::Chain#run
         def call(context, *args)
@@ -248,7 +251,7 @@ module Hanami
       # It wraps a symbol or a string representing a method name that is implemented by the context within it will be called.
       #
       # @since 0.1.0
-      # @private
+      # @api private
       class MethodCallback < Callback
         # Executes the callback within the given context and eventually passing the given arguments.
         # Those arguments will be passed according to the arity of the target method.
@@ -259,6 +262,7 @@ module Hanami
         # @return [void, Object] It may return a value, it depends on the callback.
         #
         # @since 0.1.0
+        # @api private
         #
         # @see Hanami::Utils::Callbacks::Chain#run
         def call(context, *args)
@@ -271,10 +275,12 @@ module Hanami
           end
         end
 
+        # @api private
         def hash
           callback.hash
         end
 
+        # @api private
         def eql?(other)
           hash == other.hash
         end

--- a/lib/hanami/utils/class_attribute.rb
+++ b/lib/hanami/utils/class_attribute.rb
@@ -8,6 +8,7 @@ module Hanami
     #
     # @see Hanami::Utils::ClassAttribute::ClassMethods
     module ClassAttribute
+      # @api private
       def self.included(base)
         base.extend ClassMethods
       end
@@ -75,6 +76,7 @@ module Hanami
         protected
 
         # @see Class#inherited
+        # @api private
         def inherited(subclass)
           class_attributes.each do |attr|
             value = send(attr)
@@ -89,7 +91,7 @@ module Hanami
         private
 
         # Class accessor for class attributes.
-        # @private
+        # @api private
         def class_attributes
           @class_attributes ||= Set.new
         end

--- a/lib/hanami/utils/deprecation.rb
+++ b/lib/hanami/utils/deprecation.rb
@@ -63,6 +63,7 @@ module Hanami
 
       private
 
+      # @api private
       def caller_index
         Utils.jruby? || Utils.rubinius? ? 1 : 2
       end

--- a/lib/hanami/utils/escape.rb
+++ b/lib/hanami/utils/escape.rb
@@ -415,7 +415,7 @@ module Hanami
       #   <div>&lt;script&gt;alert(1);&lt;&#x2F;script&gt;</div>
       #
       # @example Bad practice
-      #   # WRONG Use Escape.html_attribute
+      #   # WRONG Use Escape.html_attribute instead
       #   <a title="<%= Hanami::Utils::Escape.html('...') %>">link</a>
       def self.html(input)
         input = encode(input)

--- a/lib/hanami/utils/inflector.rb
+++ b/lib/hanami/utils/inflector.rb
@@ -6,8 +6,6 @@ module Hanami
     # String inflector
     #
     # @since 0.4.1
-    #
-    # rubocop:disable Style/PerlBackrefs
     module Inflector # rubocop:disable Metrics/ModuleLength
       # Rules for irregular plurals
       #
@@ -347,6 +345,7 @@ module Hanami
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Style/PerlBackrefs
       def self.pluralize(string)
         return string if string.nil? || string =~ Utils::Blank::STRING_MATCHER
 
@@ -385,6 +384,7 @@ module Hanami
           string + S
         end
       end
+      # rubocop:enable Style/PerlBackrefs
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/MethodLength
@@ -402,6 +402,7 @@ module Hanami
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Style/PerlBackrefs
       def self.singularize(string)
         return string if string.nil? || string =~ Utils::Blank::STRING_MATCHER
 
@@ -448,11 +449,11 @@ module Hanami
           string.chop
         end
       end
+      # rubocop:enable Style/PerlBackrefs
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/PerceivedComplexity
     end
-    # rubocop:enable Style/PerlBackrefs
   end
 end

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -19,10 +19,7 @@ module Hanami
   module Utils
     # Kernel utilities
     # @since 0.1.1
-    #
-    # rubocop:disable Style/MethodName
-    # rubocop:disable Metrics/ModuleLength
-    module Kernel
+    module Kernel # rubocop:disable Metrics/ModuleLength
       # Matcher for numeric values
       #
       # @since 0.3.3

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -6,11 +6,11 @@ require 'bigdecimal'
 require 'hanami/utils'
 require 'hanami/utils/string'
 
-# Define top level constant Boolean, so it can be easily used by other libraries
-# in coercions DSLs
-#
-# @since 0.3.0
 unless defined?(Boolean)
+  # Define top level constant Boolean, so it can be easily used by other libraries
+  # in coercions DSLs
+  #
+  # @since 0.3.0
   class Boolean
   end
 end


### PR DESCRIPTION
```
➜ bundle exec yardoc --no-cache --no-save --protected --private --no-api private --markup markdown lib
Files:          21
Modules:        12 (    0 undocumented)
Classes:        13 (    0 undocumented)
Constants:       2 (    0 undocumented)
Attributes:      1 (    0 undocumented)
Methods:        97 (    0 undocumented)
 100.00% documented
```

Please note that the command above will be used by our upcoming API docs website: https://github.com/hanami/docs