### PR TITLE
Use `$stdout` instead of `STDOUT` as default stream for `Hanami::Logger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 Ruby core extentions and class utilities for Hanami
 
 ## v1.0.0.beta3 (unreleased)
+### Fixed
+- [Luca Guidi] Use `$stdout` instead of `STDOUT` as default stream for `Hanami::Logger`
+
 ### Changed
 - [Luca Guidi] Removed `Utils::Attributes`
 - [Luca Guidi] Removed `Hanami::Interactor::Result#failing?`

--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -257,10 +257,10 @@ module Hanami
     #   tagging purposes
     #
     # @param stream [String, IO, StringIO, Pathname] an optional log stream. This is a filename
-    # (String) or IO object (typically STDOUT, STDERR, or an open file).
+    # (String) or IO object (typically `$stdout`, `$stderr`, or an open file).
     #
     # @since 0.5.0
-    def initialize(application_name = nil, stream: STDOUT, level: DEBUG, formatter: nil)
+    def initialize(application_name = nil, stream: $stdout, level: DEBUG, formatter: nil)
       super(stream)
 
       @level            = _level(level)

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'hanami/utils'
 require 'hanami/logger'
 require 'rbconfig'
 
@@ -16,7 +17,7 @@ describe Hanami::Logger do
   describe '#initialize' do
     it 'uses STDOUT by default' do
       output =
-        stub_stdout_constant do
+        with_captured_stdout do
           class TestLogger < Hanami::Logger; end
           logger = TestLogger.new
           logger.info('foo')
@@ -263,7 +264,7 @@ describe Hanami::Logger do
 
     it 'has application_name when log' do
       output =
-        stub_stdout_constant do
+        with_captured_stdout do
           module App; class TestLogger < Hanami::Logger; end; end
           logger = App::TestLogger.new
           logger.info('foo')
@@ -297,7 +298,7 @@ describe Hanami::Logger do
       end
 
       output =
-        stub_stdout_constant do
+        with_captured_stdout do
           TestLogger.new.info('')
         end
 
@@ -308,7 +309,7 @@ describe Hanami::Logger do
       it 'falls back to Formatter' do
         stub_time_now do
           output =
-            stub_stdout_constant do
+            with_captured_stdout do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: nil).info('foo')
             end
@@ -324,7 +325,7 @@ describe Hanami::Logger do
         it 'when passed as a symbol, it has JSON format for string messages' do
           stub_time_now do
             output =
-              stub_stdout_constant do
+              with_captured_stdout do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: :json).info('foo')
               end
@@ -339,7 +340,7 @@ describe Hanami::Logger do
         it 'has JSON format for string messages' do
           stub_time_now do
             output =
-              stub_stdout_constant do
+              with_captured_stdout do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info('foo')
               end
@@ -354,7 +355,7 @@ describe Hanami::Logger do
         it 'has JSON format for error messages' do
           stub_time_now do
             output =
-              stub_stdout_constant do
+              with_captured_stdout do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).error(Exception.new('foo'))
               end
@@ -369,7 +370,7 @@ describe Hanami::Logger do
         it 'has JSON format for hash messages' do
           stub_time_now do
             output =
-              stub_stdout_constant do
+              with_captured_stdout do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(foo: :bar)
               end
@@ -384,7 +385,7 @@ describe Hanami::Logger do
         it 'has JSON format for not string messages' do
           stub_time_now do
             output =
-              stub_stdout_constant do
+              with_captured_stdout do
                 class TestLogger < Hanami::Logger; end
                 TestLogger.new(formatter: Hanami::Logger::JSONFormatter.new).info(['foo'])
               end
@@ -398,7 +399,7 @@ describe Hanami::Logger do
       it 'when passed as a symbol, it has key=value format for string messages' do
         stub_time_now do
           output =
-            stub_stdout_constant do
+            with_captured_stdout do
               class TestLogger < Hanami::Logger; end
               TestLogger.new(formatter: :default).info('foo')
             end
@@ -409,7 +410,7 @@ describe Hanami::Logger do
       it 'has key=value format for string messages' do
         stub_time_now do
           output =
-            stub_stdout_constant do
+            with_captured_stdout do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info('foo')
             end
@@ -420,7 +421,7 @@ describe Hanami::Logger do
       it 'has key=value format for error messages' do
         stub_time_now do
           exception = nil
-          output = stub_stdout_constant do
+          output = with_captured_stdout do
             class TestLogger < Hanami::Logger; end
             begin
               raise StandardError.new('foo')
@@ -440,7 +441,7 @@ describe Hanami::Logger do
       it 'has key=value format for hash messages' do
         stub_time_now do
           output =
-            stub_stdout_constant do
+            with_captured_stdout do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(foo: :bar)
             end
@@ -451,7 +452,7 @@ describe Hanami::Logger do
       it 'has key=value format for not string messages' do
         stub_time_now do
           output =
-            stub_stdout_constant do
+            with_captured_stdout do
               class TestLogger < Hanami::Logger; end
               TestLogger.new.info(%(foo bar))
             end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,26 +19,14 @@ TEST_ENCODINGS = Encoding.name_list.each_with_object(['UTF-8']) do |encoding, re
   result << encoding if !string.nil? && string != test_string
 end
 
-def stub_stdout_constant # rubocop:disable Metrics/MethodLength
-  begin_block = <<-BLOCK
-    original_verbosity = $VERBOSE
-    $VERBOSE = nil
-
-    origin_stdout = STDOUT
-    STDOUT = StringIO.new
-  BLOCK
-  TOPLEVEL_BINDING.eval begin_block
-
+def with_captured_stdout
+  original = $stdout
+  captured = StringIO.new
+  $stdout  = captured
   yield
-  return_str = STDOUT.string
-
-  ensure_block = <<-BLOCK
-    STDOUT = origin_stdout
-    $VERBOSE = original_verbosity
-  BLOCK
-  TOPLEVEL_BINDING.eval ensure_block
-
-  return_str
+  $stdout.string
+ensure
+  $stdout = original
 end
 
 def stub_time_now


### PR DESCRIPTION
`Hanami::Logger` uses `STDOUT` as default stream. This isn't the correct stream to use.

By looking at the Ruby [core documentation](http://ruby-doc.org/core/doc/globals_rdoc.html) there is a difference between `STDOUT` and `$stdout`:

> `STDOUT`
> The standard output. The default value for `$stdout`.

> `$stdout`
> The current standard input.

The first represents the **initial** value for _standard output_, assigned when a program is started. The latter is the **current** standard output. That means a program can reassign `$stdout` for some reason and expect the rest of the system to work.

Ruby core itself uses `$stdout` and not `STDOUT`. `Kernel#puts` (aka implicit `puts`), report this comment in its [API doc](http://ruby-doc.org/core/Kernel.html#method-i-puts):

> Equivalent to
> `$stdout.puts(obj, ...)`

The bottom line is: if `$stdout` gets reassigned, `Hanami::Logger` may stop to work. This PR introduces `$stdout` as default stream.