### PR TITLE
Interactor Result can check for failure reason

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -55,11 +55,14 @@ module Hanami
 
       # Check if the current status is not successful
       #
+      # @param reason [Object] the reason of the failure to check
+      #
       # @return [TrueClass,FalseClass] the result of the check
       #
       # @since 0.9.2
-      def failure?
-        !successful?
+      def failure?(reason = nil)
+        return !successful? if reason.nil?
+        !successful? && (error == reason)
       end
 
       # Force the status to be a failure

--- a/test/interactor_test.rb
+++ b/test/interactor_test.rb
@@ -269,6 +269,18 @@ describe Hanami::Interactor do
       result = ErrorBangInteractor.new.call
       result.operations.must_equal [:persist!]
     end
+
+    it 'is true when the failure reason matches' do
+      result = ErrorBangInteractor.new.call
+      assert result.failure?(
+        'There was an error while persisting data.'
+      ).must_equal true
+    end
+
+    it 'is false when the failure reason does not match' do
+      result = ErrorBangInteractor.new.call
+      assert result.failure?('foobar').must_equal false
+    end
   end
 end
 


### PR DESCRIPTION
This commit enables a more expressive way to interact with a failure
reason.

When the interactor is failed with the `error!` method, we can check in
the result.

Inside the interactor, we fail with `error!` and the error reason.
```ruby
def call
  error!('invalid_credit_card') if payment_gateway.invalid_card?
  error!('expired_credit_card') if whatever?
  # etc...
end
```

Then when calling the interactor, we can check for the failure with a given error
```ruby
# action
def a_controller_action
  result = MyInteractor.new(some_params).call

  render :new     if result.failure?('invalid_credit_card')
  render :expired if result.failure?('expired_credit_card')
  render :success
end
```