### PR TITLE
Change repository class methods to instance methods

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -211,7 +211,7 @@ module Hanami
       #     end
       #
       #     def call
-      #       @user = UserRepository.persist(@user)
+      #       @user = UserRepository.new.persist(@user)
       #     end
       #   end
       #
@@ -237,7 +237,7 @@ module Hanami
       #
       #     # THIS WON'T BE INVOKED BECAUSE #valid? WILL RETURN false
       #     def call
-      #       @user = UserRepository.persist(@user)
+      #       @user = UserRepository.new.persist(@user)
       #     end
       #
       #     private
@@ -303,7 +303,7 @@ module Hanami
     #
     #     private
     #     def persist_email_test!
-    #       @email_test = EmailTestRepository.persist(@email_test)
+    #       @email_test = EmailTestRepository.new.persist(@email_test)
     #     end
     #
     #     # IF THIS RAISES AN EXCEPTION WE FORCE A FAILURE

--- a/lib/hanami/utils/callbacks.rb
+++ b/lib/hanami/utils/callbacks.rb
@@ -44,7 +44,7 @@ module Hanami
         #   # Append a Proc to be used as a callback, it will be wrapped by `Callback`
         #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
         #   chain.append { Authenticator.authenticate! }
-        #   chain.append { |params| ArticleRepository.find(params[:id]) }
+        #   chain.append { |params| ArticleRepository.new.find(params[:id]) }
         #
         #   # Append a Symbol as a reference to a method name that will be used as a callback.
         #   # It will wrapped by `MethodCallback`
@@ -83,7 +83,7 @@ module Hanami
         #   # Add a Proc to be used as a callback, it will be wrapped by `Callback`
         #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
         #   chain.prepend { Authenticator.authenticate! }
-        #   chain.prepend { |params| ArticleRepository.find(params[:id]) }
+        #   chain.prepend { |params| ArticleRepository.new.find(params[:id]) }
         #
         #   # Add a Symbol as a reference to a method name that will be used as a callback.
         #   # It will wrapped by `MethodCallback`


### PR DESCRIPTION
I noticed these comments were out-of-date, with the `hanami-model` change to use instance methods instead of class methods.