### PR TITLE
Introduce new interactor format

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -353,18 +353,18 @@ module Hanami
       #   end
       #
       #   Signup.new.call # => NoMethodError
-      def call(**attrs)
+      def call(*args, **kwargs)
         @__result = ::Hanami::Interactor::Result.new
-        _call(attrs) { super }
+        _call(*args, **kwargs) { super }
       end
 
       private
 
       # @api private
       # @since x.x.x
-      def _call(**attrs)
+      def _call(*args, **kwargs)
         catch :fail do
-          validate!(attrs)
+          validate!(*args, **kwargs)
           yield
         end
 
@@ -372,8 +372,8 @@ module Hanami
       end
 
       # @since x.x.x
-      def validate!(**attrs)
-        fail! unless valid?(attrs)
+      def validate!(*args, **kwargs)
+        fail! unless valid?(*args, **kwargs)
       end
     end
 

--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -501,6 +501,7 @@ module Hanami
     end
 
     def method_added(method_name)
+      super
       return unless method_name == :call
 
       if instance_method(:call).arity.zero?

--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -551,7 +551,7 @@ module Hanami
     def _exposures
       Hash[].tap do |result|
         self.class.exposures.each do |name, ivar|
-          result[name] = instance_variable_get(ivar)
+          result[name] = instance_variable_defined?(ivar) ? instance_variable_get(ivar) : nil
         end
       end
     end

--- a/spec/unit/hanami/interactor_spec.rb
+++ b/spec/unit/hanami/interactor_spec.rb
@@ -18,6 +18,23 @@ class InteractorWithoutCall
   include Hanami::Interactor
 end
 
+class InteractorWithMethodAdded
+  module MethodAdded; end
+
+  module WatchMethods
+    def method_added(method_name)
+      super
+      include MethodAdded if method_name == :call
+    end
+  end
+
+  include Hanami::Interactor
+  extend WatchMethods
+
+  def call(*)
+  end
+end
+
 class User
   def initialize(attributes = {})
     @attributes = attributes
@@ -299,6 +316,10 @@ RSpec.describe Hanami::Interactor do
 
     it "raises error when #call isn't implemented" do
       expect { InteractorWithoutCall.new.call }.to raise_error NoMethodError
+    end
+
+    it 'lets .method_added open to overrides' do
+      expect(InteractorWithMethodAdded.ancestors).to include(InteractorWithMethodAdded::MethodAdded)
     end
   end
 

--- a/spec/unit/hanami/interactor_spec.rb
+++ b/spec/unit/hanami/interactor_spec.rb
@@ -103,6 +103,16 @@ class Signup
   end
 end
 
+class ComplexCall
+  include Hanami::Interactor
+  expose :args, :kwargs
+
+  def call(*args, **kwargs)
+    @args = args
+    @kwargs = kwargs
+  end
+end
+
 class LegacyErrorInteractor
   include Hanami::Interactor
   expose :operations
@@ -479,6 +489,12 @@ RSpec.describe Hanami::Interactor do
 
       it "raises error when #call isn't implemented" do
         expect { InteractorWithoutCall.new.call }.to raise_error NoMethodError
+      end
+
+      it 'handles args and kwargs' do
+        result = ComplexCall.new.call('foo', 'bar', baz: 'baz', buzz: 'buzz')
+        expect(result.args).to eql(%w(foo bar))
+        expect(result.kwargs).to eql(Hash[baz: 'baz', buzz: 'buzz'])
       end
 
       describe 'inheritance' do


### PR DESCRIPTION
ATM, the parameters for the execution are send at the initialization of the instance. This behavior poses 2 main issues:
* it is really hard to make Dependency Injections
* there is no way to reuse an Interactor instance with other parameters

This PR aims at introducing a new format that would solve the previously mentioned issues, all the while still supporting the previous format.

New format example:

```ruby
class Hello
  include Hanami::Interactor
  expose :hello

  def call(target:)
    @hello = "Hello #{target}"
  end

  private

  def valid?(target:)
    !target == 'me'
  end
end

hello = Hello.new
hello.call(target: 'world') # => valid?: true, hello: 'Hello world'
hello.call(target: 'me') # => valid?: false
```

TODO:

- [x] prove that it can work
- [x] write all the current tests for both formats
- [x] write all the documentation