### PR TITLE
Implement Utils::Hash.deep_dup

### DIFF
--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -25,6 +25,10 @@ module Hanami
 
       # Symbolize the given hash
       #
+      # @param input [::Hash] the input
+      #
+      # @return [::Hash] the symbolized hash
+      #
       # @since x.x.x
       #
       # @see .deep_symbolize
@@ -43,6 +47,10 @@ module Hanami
 
       # Deep symbolize the given hash
       #
+      # @param input [::Hash] the input
+      #
+      # @return [::Hash] the deep symbolized hash
+      #
       # @since x.x.x
       #
       # @see .symbolize
@@ -57,6 +65,54 @@ module Hanami
       #     # => Hash
       def self.deep_symbolize(input)
         self[:deep_symbolize_keys].call(input)
+      end
+
+      # Deep duplicate hash values
+      #
+      # The output of this function is a shallow duplicate of the input.
+      # Any further modification on the input, won't be reflected on the output
+      # and viceversa.
+      #
+      # @param input [::Hash] the input
+      #
+      # @return [::Hash] the shallow duplicate of input
+      #
+      # @since x.x.x
+      #
+      # @example Basic Usage
+      #   require 'hanami/utils/hash'
+      #
+      #   input  = { "a" => { "b" => { "c" => [1, 2, 3] } } }
+      #   output = Hanami::Utils::Hash.deep_dup(input)
+      #     # => {"a"=>{"b"=>{"c"=>[1,2,3]}}}
+      #
+      #   output.class
+      #     # => Hash
+      #
+      #
+      #
+      #   # mutations on input aren't reflected on output
+      #
+      #   input["a"]["b"]["c"] << 4
+      #   output.dig("a", "b", "c")
+      #     # => [1, 2, 3]
+      #
+      #
+      #
+      #   # mutations on output aren't reflected on input
+      #
+      #   output["a"].delete("b")
+      #   input
+      #     # => {"a"=>{"b"=>{"c"=>[1,2,3,4]}}}
+      def self.deep_dup(input)
+        input.each_with_object({}) do |(k, v), result|
+          result[k] = case v
+                      when ::Hash
+                        deep_dup(v)
+                      else
+                        Duplicable.dup(v)
+                      end
+        end
       end
 
       # Initialize the hash

--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -90,6 +90,50 @@ RSpec.describe Hanami::Utils::Hash do
     end
   end
 
+  describe ".deep_dup" do
+    it "returns ::Hash" do
+      hash = described_class.deep_dup({})
+
+      expect(hash).to be_kind_of(::Hash)
+    end
+
+    it "duplicates string values" do
+      input  = { "a" => "hello" }
+      result = described_class.deep_dup(input)
+
+      result["a"] << " world"
+
+      expect(input.fetch("a")).to eq("hello")
+    end
+
+    it "duplicates array values" do
+      input  = { "a" => [1, 2, 3] }
+      result = described_class.deep_dup(input)
+
+      result["a"] << 4
+
+      expect(input.fetch("a")).to eq([1, 2, 3])
+    end
+
+    it "duplicates hash values" do
+      input  = { "a" => { "b" => 2 } }
+      result = described_class.deep_dup(input)
+
+      result["a"]["c"] = 3
+
+      expect(input.fetch("a")).to eq("b" => 2)
+    end
+
+    it "duplicates nested hashes" do
+      input  = { "a" => { "b" => { "c" => 3 } } }
+      result = described_class.deep_dup(input)
+
+      result["a"].delete("b")
+
+      expect(input).to eq("a" => { "b" => { "c" => 3 } })
+    end
+  end
+
   describe '#initialize' do
     let(:input_to_hash) do
       Class.new do


### PR DESCRIPTION
As cleanup for https://github.com/hanami/model/pull/395, we need to replace in `Hanami::Entity` `Hanami::Utils::Hash#deep_symbolize!` with `Hanami::Utils::Hash.deep_symbolize`.

The first method returns an instance of `Hanami::Utils::Hash` which respond to `#deep_dup`. The new `.deep_symbolize` returns a `::Hash`, which doesn't have `#deep_dup`. Here's the reason for this PR.

Please note, that after the merge of https://github.com/hanami/model/pull/395 `hanami-model` `master` branch is in a "dirty" state, as it requires an additional PR to reach the wanted behavior.

---

This proposal continues the idea introduced by #210 of moving `Utils::Hash` transformations away from instance methods and to port all the existing ones to class methods.

/cc @hanami/core 