### PR TITLE
Update Documentation To Not Use persist Method

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -205,12 +205,11 @@ module Hanami
       #
       #     def initialize(params)
       #       @params = params
-      #       @user   = User.new(@params)
       #       @foo    = 'bar'
       #     end
       #
       #     def call
-      #       @user = UserRepository.new.persist(@user)
+      #       @user = UserRepository.new.create(@params)
       #     end
       #   end
       #
@@ -231,12 +230,11 @@ module Hanami
       #
       #     def initialize(params)
       #       @params = params
-      #       @user   = User.new(@params)
       #     end
       #
       #     # THIS WON'T BE INVOKED BECAUSE #valid? WILL RETURN false
       #     def call
-      #       @user = UserRepository.new.persist(@user)
+      #       @user = UserRepository.new.create(@params)
       #     end
       #
       #     private
@@ -292,7 +290,6 @@ module Hanami
     #
     #     def initialize(params)
     #       @params     = params
-    #       @email_test = EmailTest.new(@params)
     #     end
     #
     #     def call
@@ -302,7 +299,7 @@ module Hanami
     #
     #     private
     #     def persist_email_test!
-    #       @email_test = EmailTestRepository.new.persist(@email_test)
+    #       @email_test = EmailTestRepository.new.create(@params)
     #     end
     #
     #     # IF THIS RAISES AN EXCEPTION WE FORCE A FAILURE


### PR DESCRIPTION
Update documentation for the persisting of the repository to use the
create method instead of the persist method due to the persist method
not existing for quite some time.

The example could confuse a user trying to implement the pattern causing
false issues being posted or time loss.

Relates to issue #213