### PR TITLE
Test frozen input for Utils::Hash#initialize

### DIFF
--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -176,6 +176,13 @@ RSpec.describe Hanami::Utils::Hash do
       expect(hash.to_h).to eq(input_to_hash.to_hash)
     end
 
+    it 'accepts frozen values' do
+      pending
+
+      expect { Hanami::Utils::Hash.new({}.freeze) }
+        .to_not raise_error
+    end
+
     it "raises error when object doesn't implement #to_hash" do
       expect { Hanami::Utils::Hash.new(input_to_h) }
         .to raise_error(NoMethodError)


### PR DESCRIPTION
This test does currently not pass and is merely a suggestion for defining its behavior. Personally, I think it's a tad bit icky to modify arguments and I would like to be able to duplicate frozen objects. What do you think?