### PR TITLE
Hanami::Events to implement Pub/Sub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test/tmp
 test/version_tmp
 tmp
 bin
+*.swp

--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake',    '~> 11'
   spec.add_development_dependency 'rspec',   '~> 3.5'
+  spec.add_development_dependency 'wisper',  '~> 2.0'
 end

--- a/lib/hanami/events.rb
+++ b/lib/hanami/events.rb
@@ -1,0 +1,23 @@
+require 'hanami/utils/class_attribute'
+
+module Hanami
+  # Event framework for Hanami
+  module Events
+    include Utils::ClassAttribute
+    class_attribute :backend
+
+    def self.subscribe(event_type, subscriber = nil, &blk)
+      backend.subscribe(event_type, subscriber || blk)
+    end
+
+    def self.broadcast(event_type, payload)
+      backend.broadcast(event_type, payload)
+    end
+  end
+end
+
+begin
+  require 'hanami/events/backends/wisper'
+rescue LoadError
+  raise "Couldn't find `wisper` gem. Please, add `gem 'wisper', '2.0.0'` to Gemfile in order to use `Hanami::Events`"
+end

--- a/lib/hanami/events/backends/wisper.rb
+++ b/lib/hanami/events/backends/wisper.rb
@@ -1,0 +1,24 @@
+require 'wisper'
+
+module Hanami
+  module Events
+    # Backends for Hanami::Events
+    module Backends
+      # Memory backend for Hanami::Events
+      class Wisper
+        include ::Wisper::Publisher
+
+        def subscribe(event_type, subscriber)
+          ::Wisper.subscribe(subscriber, on: event_type, with: :call)
+        end
+
+        def broadcast(*args)
+          super
+        end
+      end
+    end
+  end
+end
+
+Hanami::Events.backend = Hanami::Events::Backends::Wisper.new
+Hanami::Events.include(::Wisper::Publisher)

--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -2,6 +2,7 @@
 #
 # @since 0.1.0
 module Hanami
+  require 'hanami/events'
   require 'hanami/utils/version'
   require 'hanami/utils/file_list'
 

--- a/spec/unit/hanami/events_spec.rb
+++ b/spec/unit/hanami/events_spec.rb
@@ -1,0 +1,94 @@
+require 'hanami/events'
+
+RSpec.describe Hanami::Events do
+  after { Wisper.clear }
+
+  context '.subscribe' do
+    it 'allows to subscribe with a proc' do
+      expect { Hanami::Events.subscribe('user_signed_up') { |event| } }.to_not(
+        raise_error
+      )
+    end
+
+    it 'allows to subscribe with an object' do
+      expect { Hanami::Events.subscribe('user_signed_up', ->(e) {}) }.to_not(
+        raise_error
+      )
+    end
+  end
+
+  context '.broadcast' do
+    it 'broadcasts event to single subscriber object' do
+      mailer = double('mailer')
+
+      Hanami::Events.subscribe('user_signed_up', mailer)
+      expect(mailer).to receive(:call).with(id: 1, email: 'user@hanamirb.org')
+
+      Hanami::Events.broadcast(
+        'user_signed_up', id: 1, email: 'user@hanamirb.org'
+      )
+    end
+
+    it 'broadcasts event to single proc subscriber' do
+      Hanami::Events.subscribe('user_signed_up') do |event|
+        puts "user signed up: #{event[:id]}"
+      end
+
+      expect(STDOUT).to receive(:puts).with('user signed up: 1')
+
+      Hanami::Events.broadcast(
+        'user_signed_up', id: 1, email: 'user@hanamirb.org'
+      )
+    end
+
+    it 'broadcasts event to multiple subscribers' do
+      mailer = double('mailer')
+      analytics = double('anaytics')
+
+      Hanami::Events.subscribe('user_signed_up', mailer)
+      Hanami::Events.subscribe('user_signed_up', analytics)
+      expect(mailer).to receive(:call).with(email: 'user@hanamirb.org')
+      expect(analytics).to receive(:call).with(email: 'user@hanamirb.org')
+
+      Hanami::Events.broadcast('user_signed_up', email: 'user@hanamirb.org')
+    end
+
+    it 'broadcasts multiple events to single subscriber' do
+      mailer = double('mailer')
+
+      Hanami::Events.subscribe('user_signed_up', mailer)
+      Hanami::Events.subscribe('user_updated_profile', mailer)
+
+      expect(mailer).to receive(:call).with(email: 'user@hanamirb.org').twice
+
+      Hanami::Events.broadcast('user_signed_up', email: 'user@hanamirb.org')
+      Hanami::Events.broadcast(
+        'user_updated_profile', email: 'user@hanamirb.org'
+      )
+    end
+  end
+
+  context 'when Hanami::Events included into class' do
+    let(:signup) do
+      Class.new do
+        include Hanami::Events
+
+        def call(input)
+          broadcast('user_signed_up', input)
+        end
+      end
+    end
+
+    context '#broadcast' do
+      it 'broadcasts an event' do
+        Hanami::Events.subscribe('user_signed_up') do |event|
+          puts "welcome message for #{event[:id]}"
+        end
+
+        expect(STDOUT).to receive(:puts).with('welcome message for 23')
+
+        signup.new.call(id: 23)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implementation of `Hanami::Events` using Wisper gem as a backend.

Implements the API provided in this PR: https://github.com/hanami/utils/pull/160

## Usage

### Subscribe With A Proc

```ruby
require 'hanami/events'

Hanami::Events.subscribe('user_signed_up') do |event|
  puts "New signup: #{event[:email]}"
end

Hanami::Events.broadcast('user_signed_up', id: 1, email: "user@hanamirb.org")

# => "New signup: user@hanamirb.org
```

### Subscribe With An object

```ruby
require 'hanami/events'

class WelcomeMailer
  def call(event)
    puts "New welcome message for: #{event[:email]}"
  end
end

Hanami::Events.subscribe('user_signed_up', WelcomeMailer.new)
Hanami::Events.broadcast('user_signed_up', id: 1, email: "user@hanamirb.org")

# => "New welcome message for: user@hanamirb.org
```

### Include Mixin

```ruby
require 'hanami/events'

class Signup
  include Hanami::Events

  def call(params)
    broadcast('user_signed_up', params)
  end
end

Hanami::Events.subscribe('user_signed_up') do |event|
  puts "New signup: #{event[:email]}"
end

Signup.new.call(email: "user@hanamirb.org")
# => "New signup: user@hanamirb.org
```