### PR TITLE
Introduce `Utils::Files`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 # Please keep AllCops, Bundler, Style, Metrics groups and then order cops
 # alphabetically
+AllCops:
+  TargetRubyVersion: 2.3
 inherit_from:
   - https://raw.githubusercontent.com/hanami/hanami/master/.rubocop.yml
 Metrics/BlockLength:
@@ -16,3 +18,5 @@ Style/MethodMissing:
 Style/MethodName:
   Exclude:
     - 'lib/hanami/utils/kernel.rb'
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -6,13 +6,13 @@ module Hanami
     # Files utilities
     #
     # @since x.x.x
-    module Files
+    module Files # rubocop:disable Metrics/ModuleLength
       def self.touch(path)
         write(path, "")
       end
 
       def self.write(path, *content)
-        mkdir(path)
+        mkdir_p(path)
         open(path, ::File::CREAT | ::File::WRONLY, *content)
       end
 
@@ -21,11 +21,15 @@ module Hanami
       end
 
       def self.cp(source, destination)
-        mkdir(destination)
+        mkdir_p(destination)
         FileUtils.cp(source, destination)
       end
 
       def self.mkdir(path)
+        FileUtils.mkdir_p(path)
+      end
+
+      def self.mkdir_p(path)
         Pathname.new(path).dirname.mkpath
       end
 

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -1,0 +1,86 @@
+module Hanami
+  module Utils
+    # Files utilities
+    #
+    # @since x.x.x
+    module Files
+      def self.touch(path)
+        write(path, "")
+      end
+
+      def self.write(path, *content)
+        Pathname.new(path).dirname.mkpath
+        open(path, ::File::CREAT | ::File::WRONLY, *content)
+      end
+
+      def self.rewrite(path, *content)
+        open(path, ::File::TRUNC | ::File::WRONLY, *content)
+      end
+
+      def self.replace(path, target, replacement)
+        content = ::File.readlines(path)
+        content[index(content, path, target)] = "#{replacement}\n"
+
+        rewrite(path, content)
+      end
+
+      def self.replace_last(path, target, replacement)
+        content = ::File.readlines(path)
+        content[-index(content.reverse, path, target) - 1] = "#{replacement}\n"
+
+        rewrite(path, content)
+      end
+
+      def self.unshift(path, line)
+        content = ::File.readlines(path)
+        content.unshift("#{line}\n")
+
+        rewrite(path, content)
+      end
+
+      def self.append(path, contents)
+        content = ::File.readlines(path)
+        content << "#{contents}\n"
+
+        rewrite(path, content)
+      end
+
+      def self.remove_block(path, target) # rubocop:disable Metrics/AbcSize
+        content  = ::File.readlines(path)
+        starting = index(content, path, target)
+        line     = content[starting]
+        size     = line[/\A[[:space:]]*/].bytesize
+        closing  = (" " * size) + (target =~ /{/ ? '}' : 'end')
+        ending   = starting + index(content[starting..-1], path, closing)
+
+        content.slice!(starting..ending)
+        rewrite(path, content)
+
+        remove_block(path, target) if containts?(content, target)
+      end
+
+      def self.open(path, mode, *content)
+        ::File.open(path, mode) do |file|
+          file.write(Array(content).flatten.join)
+        end
+      end
+
+      def self.contents(path)
+        ::IO.read(Hanami.root.join(path))
+      end
+
+      def self.index(content, path, target)
+        line_number(content, target) or
+          raise ArgumentError.new("Cannot find `#{target}' inside `#{path}'.")
+      end
+
+      def self.containts?(content, target)
+        !line_number(content, target).nil?
+      end
+
+      def self.line_number(content, target)
+        content.index { |l| l.include?(target) }
+      end
+    end
+  end
+end

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -20,7 +20,7 @@ module Hanami
 
       # Creates a new file for the given path and content.
       # All the intermediate directories are created.
-      # If the path already exists, it overrides the contents.
+      # If the path already exists, it appends the contents.
       #
       # @param path [String,Pathname] the path to file
       # @param content [String, Array<String>] the content to write
@@ -31,8 +31,17 @@ module Hanami
         open(path, ::File::CREAT | ::File::WRONLY, *content)
       end
 
-      class << self
-        alias rewrite write
+      # Rewrites the contents of an existing file.
+      # If the path already exists, it replaces the contents.
+      #
+      # @param path [String,Pathname] the path to file
+      # @param content [String, Array<String>] the content to write
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      #
+      # @since x.x.x
+      def self.rewrite(path, *content)
+        open(path, ::File::TRUNC | ::File::WRONLY, *content)
       end
 
       # Copies source into destination.
@@ -117,20 +126,16 @@ module Hanami
         FileUtils.remove_entry_secure(path)
       end
 
-      def self.replace(path, target, replacement)
-        content = ::File.readlines(path)
-        content[index(content, path, target)] = "#{replacement}\n"
-
-        rewrite(path, content)
-      end
-
-      def self.replace_last(path, target, replacement)
-        content = ::File.readlines(path)
-        content[-index(content.reverse, path, target) - 1] = "#{replacement}\n"
-
-        rewrite(path, content)
-      end
-
+      # Adds a new line at the top of the file
+      #
+      # @param path [String,Pathname] the path to file
+      # @param line [String] the line to add
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      #
+      # @see .append
+      #
+      # @since x.x.x
       def self.unshift(path, line)
         content = ::File.readlines(path)
         content.unshift("#{line}\n")
@@ -138,6 +143,16 @@ module Hanami
         rewrite(path, content)
       end
 
+      # Adds a new line at the bottom of the file
+      #
+      # @param path [String,Pathname] the path to file
+      # @param line [String] the line to add
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      #
+      # @see .unshift
+      #
+      # @since x.x.x
       def self.append(path, contents)
         mkdir_p(path)
 
@@ -147,22 +162,130 @@ module Hanami
         rewrite(path, content)
       end
 
-      def self.inject_after(path, contents, after)
+      # Replace line in `path` that contains `target` with `replacement`.
+      #
+      # @param path [String,Pathname] the path to file
+      # @param target [String,Regexp] the target to replace
+      # @param replacement [String] the replacement
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      # @raises [ArgumentError] if `target` cannot be found in `path`
+      #
+      # @see .replace_last_line
+      #
+      # @since x.x.x
+      def self.replace_line(path, target, replacement)
         content = ::File.readlines(path)
-        i       = index(content, path, after)
+        content[index(content, path, target)] = "#{replacement}\n"
+
+        rewrite(path, content)
+      end
+
+      # Replace last line in `path` that contains `target` with `replacement`.
+      #
+      # @param path [String,Pathname] the path to file
+      # @param target [String,Regexp] the target to replace
+      # @param replacement [String] the replacement
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      # @raises [ArgumentError] if `target` cannot be found in `path`
+      #
+      # @see .replace_line
+      #
+      # @since x.x.x
+      def self.replace_last_line(path, target, replacement)
+        content = ::File.readlines(path)
+        content[-index(content.reverse, path, target) - 1] = "#{replacement}\n"
+
+        rewrite(path, content)
+      end
+
+      # Inject `contents` in `path` before `target`.
+      #
+      # @param path [String,Pathname] the path to file
+      # @param target [String,Regexp] the target to replace
+      # @param contents [String] the contents to inject
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      # @raises [ArgumentError] if `target` cannot be found in `path`
+      #
+      # @see .inject_line_after
+      #
+      # @since x.x.x
+      def self.inject_line_before(path, target, contents)
+        content = ::File.readlines(path)
+        i       = index(content, path, target)
+
+        content.insert(i, "#{contents}\n")
+        rewrite(path, content)
+      end
+
+      # Inject `contents` in `path` after `target`.
+      #
+      # @param path [String,Pathname] the path to file
+      # @param target [String,Regexp] the target to replace
+      # @param contents [String] the contents to inject
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      # @raises [ArgumentError] if `target` cannot be found in `path`
+      #
+      # @see .inject_line_before
+      #
+      # @since x.x.x
+      def self.inject_line_after(path, target, contents)
+        content = ::File.readlines(path)
+        i       = index(content, path, target)
 
         content.insert(i + 1, "#{contents}\n")
         rewrite(path, content)
       end
 
-      def self.remove_line(path, contents)
+      # Removes line from `path`, matching `target`.
+      #
+      # @param path [String,Pathname] the path to file
+      # @param target [String,Regexp] the target to remove
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      # @raises [ArgumentError] if `target` cannot be found in `path`
+      #
+      # @since x.x.x
+      def self.remove_line(path, target)
         content = ::File.readlines(path)
-        i       = index(content, path, contents)
+        i       = index(content, path, target)
 
         content.delete_at(i)
         rewrite(path, content)
       end
 
+      # Removes `target` block from `path`
+      #
+      # @param path [String,Pathname] the path to file
+      # @param target [String] the target block to remove
+      #
+      # @raises [Errno::ENOENT] if the path doesn't exist
+      # @raises [ArgumentError] if `target` cannot be found in `path`
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require "hanami/utils/files"
+      #
+      #   puts File.read("app.rb")
+      #
+      #   # class App
+      #   #   configure do
+      #   #     root __dir__
+      #   #   end
+      #   # end
+      #
+      #   Hanami::Utils::Files.remove_block("app.rb", "configure")
+      #
+      #
+      #
+      #   puts File.read("app.rb")
+      #
+      #   # class App
+      #   # end
       def self.remove_block(path, target) # rubocop:disable Metrics/AbcSize
         content  = ::File.readlines(path)
         starting = index(content, path, target)
@@ -174,52 +297,78 @@ module Hanami
         content.slice!(starting..ending)
         rewrite(path, content)
 
-        remove_block(path, target) if containts?(content, target)
+        remove_block(path, target) if match?(content, target)
       end
 
+      # Checks if `path` exist
+      #
+      # @param path [String,Pathname] the path to file
+      #
+      # @returns [TrueClass,FalseClass] the result of the check
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require "hanami/utils/files"
+      #
+      #   Hanami::Utils::Files.exist?(__FILE__) # => true
+      #   Hanami::Utils::Files.exist?(__dir__)  # => true
+      #
+      #   Hanami::Utils::Files.exist?("missing_file") # => false
       def self.exist?(path)
         File.exist?(path)
       end
 
+      # Checks if `path` is a directory
+      #
+      # @param path [String,Pathname] the path to directory
+      #
+      # @returns [TrueClass,FalseClass] the result of the check
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require "hanami/utils/files"
+      #
+      #   Hanami::Utils::Files.directory?(__dir__)  # => true
+      #   Hanami::Utils::Files.directory?(__FILE__) # => false
+      #
+      #   Hanami::Utils::Files.directory?("missing_directory") # => false
       def self.directory?(path)
         File.directory?(path)
       end
 
-      def self.containts?(content, target)
+      # private
+
+      # @since x.x.x
+      # @api private
+      def self.match?(content, target)
         !line_number(content, target).nil?
       end
 
-      # private
+      private_class_method :match?
 
+      # @since x.x.x
+      # @api private
       def self.open(path, mode, *content)
         ::File.open(path, mode) do |file|
           file.write(Array(content).flatten.join)
         end
       end
 
-      def self.contents(path)
-        ::IO.read(Hanami.root.join(path))
-      end
+      private_class_method :open
 
-      def self.read_matching_line(path, target)
-        content = ::File.readlines(path)
-        line    = content.find do |l|
-          case target
-          when ::String
-            l.include?(target)
-          when Regexp
-            l =~ target
-          end
-        end
-
-        line or raise ArgumentError.new("Cannot find `#{target}' inside `#{path}'.")
-      end
-
+      # @since x.x.x
+      # @api private
       def self.index(content, path, target)
         line_number(content, target) or
           raise ArgumentError.new("Cannot find `#{target}' inside `#{path}'.")
       end
 
+      private_class_method :index
+
+      # @since x.x.x
+      # @api private
       def self.line_number(content, target)
         content.index do |l|
           case target
@@ -230,6 +379,8 @@ module Hanami
           end
         end
       end
+
+      private_class_method :line_number
     end
   end
 end

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -98,7 +98,7 @@ module Hanami
       #     # => creates the `path/to` directory, but NOT `file.rb`
       #
       #   # WRONG it doesn't create the last directory, check `.mkdir`
-      #   Hanami::Utils::Files.mkdir("path/to/directory")
+      #   Hanami::Utils::Files.mkdir_p("path/to/directory")
       #     # => creates the `path/to` directory
       def self.mkdir_p(path)
         Pathname.new(path).dirname.mkpath
@@ -162,7 +162,7 @@ module Hanami
         rewrite(path, content)
       end
 
-      # Replace line in `path` that contains `target` with `replacement`.
+      # Replace first line in `path` that contains `target` with `replacement`.
       #
       # @param path [String,Pathname] the path to file
       # @param target [String,Regexp] the target to replace
@@ -174,7 +174,7 @@ module Hanami
       # @see .replace_last_line
       #
       # @since x.x.x
-      def self.replace_line(path, target, replacement)
+      def self.replace_first_line(path, target, replacement)
         content = ::File.readlines(path)
         content[index(content, path, target)] = "#{replacement}\n"
 
@@ -190,7 +190,7 @@ module Hanami
       # @raises [Errno::ENOENT] if the path doesn't exist
       # @raises [ArgumentError] if `target` cannot be found in `path`
       #
-      # @see .replace_line
+      # @see .replace_first_line
       #
       # @since x.x.x
       def self.replace_last_line(path, target, replacement)
@@ -279,8 +279,6 @@ module Hanami
       #   # end
       #
       #   Hanami::Utils::Files.remove_block("app.rb", "configure")
-      #
-      #
       #
       #   puts File.read("app.rb")
       #

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -115,7 +115,7 @@ module Hanami
         content = ::File.readlines(path)
         line    = content.find do |l|
           case target
-          when String
+          when ::String
             l.include?(target)
           when Regexp
             l =~ target
@@ -145,7 +145,7 @@ module Hanami
       def self.line_number(content, target)
         content.index do |l|
           case target
-          when String
+          when ::String
             l.include?(target)
           when Regexp
             l =~ target

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -63,7 +63,7 @@ module Hanami
       end
 
       def self.append(path, contents)
-        mkdir(path)
+        mkdir_p(path)
 
         content = ::File.readlines(path)
         content << "#{contents}\n"

--- a/spec/support/files.rb
+++ b/spec/support/files.rb
@@ -1,0 +1,11 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_content do |expected|
+  match do |actual|
+    File.read(actual) == expected
+  end
+
+  failure_message do |actual|
+    "expected that `#{actual}' would be have content '#{expected}', but it has '#{File.read(actual)}'"
+  end
+end

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -158,7 +158,11 @@ RSpec.describe Hanami::Utils::Files do
 
     it "raises error if path doesn't exist" do
       path = root.join("delete", "file")
-      expect { described_class.delete(path) }.to raise_error(Errno::ENOENT, "No such file or directory @ unlink_internal - #{path}")
+
+      expect { described_class.delete(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to match("No such file or directory")
+      end
 
       expect(path).to_not exist
     end
@@ -175,7 +179,11 @@ RSpec.describe Hanami::Utils::Files do
 
     it "raises error if directory doesn't exist" do
       path = root.join("delete", "directory")
-      expect { described_class.delete_directory(path) }.to raise_error(Errno::ENOENT, "No such file or directory @ rb_file_s_lstat - #{path}")
+
+      expect { described_class.delete_directory(path) }.to raise_error do |exception|
+        expect(exception).to be_kind_of(Errno::ENOENT)
+        expect(exception.message).to match("No such file or directory")
+      end
 
       expect(path).to_not exist
     end

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hanami::Utils::Files do
       expect(path).to have_content(":)")
     end
 
-    it "replaces previous contentes" do
+    it "replaces previous contents" do
       path = root.join("write")
       described_class.write(path, "some words")
       described_class.write(path, "some other words")
@@ -99,7 +99,7 @@ RSpec.describe Hanami::Utils::Files do
       source.delete if source.exist?
     end
 
-    it "creates an file with given contents" do
+    it "creates a file with given contents" do
       described_class.write(source, "the source")
 
       destination = root.join("cp")
@@ -276,7 +276,7 @@ RSpec.describe Hanami::Utils::Files do
     end
   end
 
-  describe ".replace_line" do
+  describe ".replace_first_line" do
     it "replaces string target with replacement" do
       path = root.join("replace_string.rb")
       content = <<~EOF
@@ -287,7 +287,7 @@ RSpec.describe Hanami::Utils::Files do
       EOF
 
       described_class.write(path, content)
-      described_class.replace_line(path, "perform", "  def self.call(input)")
+      described_class.replace_first_line(path, "perform", "  def self.call(input)")
 
       expected = <<~EOF
         class Replace
@@ -309,7 +309,7 @@ RSpec.describe Hanami::Utils::Files do
       EOF
 
       described_class.write(path, content)
-      described_class.replace_line(path, /perform/, "  def self.call(input)")
+      described_class.replace_first_line(path, /perform/, "  def self.call(input)")
 
       expected = <<~EOF
         class Replace
@@ -334,7 +334,7 @@ RSpec.describe Hanami::Utils::Files do
       EOF
 
       described_class.write(path, content)
-      described_class.replace_line(path, "perform", "  def self.call(input)")
+      described_class.replace_first_line(path, "perform", "  def self.call(input)")
 
       expected = <<~EOF
         class Replace
@@ -360,7 +360,7 @@ RSpec.describe Hanami::Utils::Files do
 
       described_class.write(path, content)
 
-      expect { described_class.replace_line(path, "not existing target", "  def self.call(input)") }.to raise_error do |exception|
+      expect { described_class.replace_first_line(path, "not existing target", "  def self.call(input)") }.to raise_error do |exception|
         expect(exception).to be_kind_of(ArgumentError)
         expect(exception.message).to eq("Cannot find `not existing target' inside `#{path}'.")
       end
@@ -371,7 +371,7 @@ RSpec.describe Hanami::Utils::Files do
     it "raises error if path doesn't exist" do
       path = root.join("replace_no_exist.rb")
 
-      expect { described_class.replace_line(path, "perform", "  def self.call(input)") }.to raise_error do |exception|
+      expect { described_class.replace_first_line(path, "perform", "  def self.call(input)") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Errno::ENOENT)
         expect(exception.message).to match("No such file or directory")
       end

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -1,0 +1,183 @@
+require "hanami/utils/files"
+require "securerandom"
+
+RSpec.describe Hanami::Utils::Files do
+  let(:root) { Pathname.new(Dir.pwd).join("tmp", SecureRandom.uuid).tap(&:mkpath) }
+
+  after do
+    FileUtils.remove_entry_secure(root)
+  end
+
+  describe ".touch" do
+    it "creates an empty file" do
+      path = root.join("touch")
+      described_class.touch(path)
+
+      expect(path).to exist
+      expect(path).to have_content("")
+    end
+
+    it "creates intermediate directories" do
+      path = root.join("path", "to", "file", "touch")
+      described_class.touch(path)
+
+      expect(path).to exist
+      expect(path).to have_content("")
+    end
+
+    it "leaves untouched existing file" do
+      path = root.join("touch")
+      path.open("wb+") { |p| p.write("foo") }
+      described_class.touch(path)
+
+      expect(path).to exist
+      expect(path).to have_content("foo")
+    end
+  end
+
+  describe ".write" do
+    it "creates an file with given contents" do
+      path = root.join("write")
+      described_class.write(path, "Hello\nWorld")
+
+      expect(path).to exist
+      expect(path).to have_content("Hello\nWorld")
+    end
+
+    it "creates intermediate directories" do
+      path = root.join("path", "to", "file", "write")
+      described_class.write(path, ":)")
+
+      expect(path).to exist
+      expect(path).to have_content(":)")
+    end
+
+    it "overrides previous contentes" do
+      path = root.join("write")
+      described_class.write(path, "some words")
+      described_class.write(path, "some other words")
+
+      expect(path).to exist
+      expect(path).to have_content("some other words")
+    end
+
+    it "is aliased as rewrite" do
+      path = root.join("rewrite")
+      described_class.rewrite(path, "rewrite me")
+
+      expect(path).to exist
+      expect(path).to have_content("rewrite me")
+    end
+  end
+
+  describe ".cp" do
+    let(:source) { root.join("..", "source") }
+
+    before do
+      source.delete if source.exist?
+    end
+
+    it "creates an file with given contents" do
+      described_class.write(source, "the source")
+
+      destination = root.join("cp")
+      described_class.cp(source, destination)
+
+      expect(destination).to exist
+      expect(destination).to have_content("the source")
+    end
+
+    it "creates intermediate directories" do
+      source = root.join("..", "source")
+      described_class.write(source, "the source for intermediate directories")
+
+      destination = root.join("cp", "destination")
+      described_class.cp(source, destination)
+
+      expect(destination).to exist
+      expect(destination).to have_content("the source for intermediate directories")
+    end
+
+    it "overrides already existing file" do
+      source = root.join("..", "source")
+      described_class.write(source, "the source")
+
+      destination = root.join("cp")
+      described_class.write(destination, "the destination")
+      described_class.cp(source, destination)
+
+      expect(destination).to exist
+      expect(destination).to have_content("the source")
+    end
+  end
+
+  describe ".mkdir" do
+    it "creates directory" do
+      path = root.join("mkdir")
+      described_class.mkdir(path)
+
+      expect(path).to be_directory
+    end
+
+    it "creates intermediate directories" do
+      path = root.join("path", "to", "mkdir")
+      described_class.mkdir(path)
+
+      expect(path).to be_directory
+    end
+  end
+
+  describe ".mkdir_p" do
+    it "creates directory" do
+      directory = root.join("mkdir_p")
+      path = directory.join("file.rb")
+      described_class.mkdir_p(path)
+
+      expect(directory).to be_directory
+      expect(path).to_not  exist
+    end
+
+    it "creates intermediate directories" do
+      directory = root.join("path", "to", "mkdir_p")
+      path = directory.join("file.rb")
+      described_class.mkdir_p(path)
+
+      expect(directory).to be_directory
+      expect(path).to_not  exist
+    end
+  end
+
+  describe ".delete" do
+    it "deletes path" do
+      path = root.join("delete", "file")
+      described_class.touch(path)
+      described_class.delete(path)
+
+      expect(path).to_not exist
+    end
+
+    it "raises error if path doesn't exist" do
+      path = root.join("delete", "file")
+      expect { described_class.delete(path) }.to raise_error(Errno::ENOENT, "No such file or directory @ unlink_internal - #{path}")
+
+      expect(path).to_not exist
+    end
+  end
+
+  describe ".delete_directory" do
+    it "deletes directory" do
+      path = root.join("delete", "directory")
+      described_class.mkdir(path)
+      described_class.delete_directory(path)
+
+      expect(path).to_not exist
+    end
+
+    it "raises error if directory doesn't exist" do
+      path = root.join("delete", "directory")
+      expect { described_class.delete_directory(path) }.to raise_error(Errno::ENOENT, "No such file or directory @ rb_file_s_lstat - #{path}")
+
+      expect(path).to_not exist
+    end
+  end
+end


### PR DESCRIPTION
This is a set of helpers that we were using since long time in `hanami` test suite.

With the new CLI for `hanami`, based on `hanami-cli`, we needed to extract that helpers from the test suite and promote it as production code.

Ref https://github.com/hanami/hanami/pull/808