### PR TITLE
Introduce `Hanami::Utils::String.transform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Ruby core extentions and class utilities for Hanami
 - [Marion Schleifer] Introduce `Utils::Hash.stringify`
 - [Marion Schleifer] Introduce `Utils::String.titleize`, `.capitalize`, `.classify`, `.underscore`, `.dasherize`, `.demodulize`, `.namespace`, `.pluralize`, `.singularize`, and `.rsub`
 - [Luca Guidi] Introduce `Utils::Files`: a set of utils for file manipulations
+- [Luca Guidi] Introduce `Utils::String.transform` a pipelined transformations for strings
 - [Gabriel Gizotti & Marion Duprey] Filter sensitive informations for `Hanami::Logger`
 
 ## v1.0.2 - 2017-07-10

--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_dependency 'transproc', '~> 1.0'
+  spec.add_dependency 'transproc',       '~> 1.0'
+  spec.add_dependency 'concurrent-ruby', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake',    '~> 11'

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -56,7 +56,13 @@ RSpec.describe Hanami::Utils::String do
     it "raises error when given proc has arity not equal to 1" do
       input = "Cherry"
 
-      expect { Hanami::Utils::String.transform(input, -> { "blossom" }) }.to raise_error(ArgumentError, %(wrong number of arguments (given 1, expected 0)))
+      message = if Hanami::Utils.jruby?
+                  "wrong number of arguments (1 for 0)"
+                else
+                  "wrong number of arguments (given 1, expected 0)"
+                end
+
+      expect { Hanami::Utils::String.transform(input, -> { "blossom" }) }.to raise_error(ArgumentError, message)
     end
   end
 

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -1,6 +1,65 @@
 require 'hanami/utils/string'
 
 RSpec.describe Hanami::Utils::String do
+  describe ".transform" do
+    it "applies multiple transformations" do
+      input = "hanami/utils"
+      actual = Hanami::Utils::String.transform(input, :underscore, :classify)
+
+      expect(input).to  eq("hanami/utils")
+      expect(actual).to eq("Hanami::Utils")
+      expect(actual).to be_kind_of(::String)
+    end
+
+    it "applies multiple transformations with args" do
+      input = "hanami/utils/string"
+      actual = Hanami::Utils::String.transform(input, [:rsub, %r{/}, "#"])
+
+      expect(input).to  eq("hanami/utils/string")
+      expect(actual).to eq("hanami/utils#string")
+      expect(actual).to be_kind_of(::String)
+    end
+
+    it "applies transformations from proc" do
+      input = "Hanami"
+      actual = Hanami::Utils::String.transform(input, ->(i) { i.upcase })
+
+      expect(input).to  eq("Hanami")
+      expect(actual).to eq("HANAMI")
+      expect(actual).to be_kind_of(::String)
+    end
+
+    it "applies transformations from ::String" do
+      input = "Hanami::Utils::String"
+      actual = Hanami::Utils::String.transform(input, :demodulize, :downcase)
+
+      expect(input).to  eq("Hanami::Utils::String")
+      expect(actual).to eq("string")
+      expect(actual).to be_kind_of(::String)
+    end
+
+    it "applies multiple transformations from ::String" do
+      input = "Hanami::Utils::String"
+      actual = Hanami::Utils::String.transform(input, [:gsub, /[aeiouy]/, "*"], :namespace)
+
+      expect(input).to  eq("Hanami::Utils::String")
+      expect(actual).to eq("H*n*m*")
+      expect(actual).to be_kind_of(::String)
+    end
+
+    it "raises error when try to apply unknown transformation" do
+      input = "Sakura"
+
+      expect { Hanami::Utils::String.transform(input, :unknown) }.to raise_error(NoMethodError, %(undefined method `:unknown' for "Sakura":String))
+    end
+
+    it "raises error when given proc has arity not equal to 1" do
+      input = "Cherry"
+
+      expect { Hanami::Utils::String.transform(input, -> { "blossom" }) }.to raise_error(ArgumentError, %(wrong number of arguments (given 1, expected 0)))
+    end
+  end
+
   describe '.titleize' do
     it '::String' do
       expect(Hanami::Utils::String.titleize('hanami')).to be_kind_of(::String)


### PR DESCRIPTION
## Proposal

Apply the given transformation(s) to `input`

It performs a pipeline of transformations, by applying the given functions from `Hanami::Utils::String` and `::String`

The transformations are applied with the given order.

It doesn't mutate the input, unless a developer uses destructive methods from `::String`

## Usage

```ruby
require "hanami/utils/string"

# Apply transformations from `Hanami::Utils::String`
Hanami::Utils::String.transform("hanami/utils", :underscore, :classify)
  # => "Hanami::Utils"

# Apply transformations from `::String`
Hanami::Utils::String.transform("Hanami", :downcase, :reverse)
  # => "imanaH"

# Apply transformations with arguments
Hanami::Utils::String.transform("Hanami::Utils::String", [:gsub, /[aeiouy]/, "*"], :demodulize)
  # => "H*n*m*"

# Apply proc transformations
Hanami::Utils::String.transform("Hanami", ->(s) { s.upcase })
  # => "HANAMI"
```

## Why?

In our codebase we have chained transformations like:

```ruby
Hanami::Utils::String.new(string).underscore.classify
```

or

```ruby
Hanami::Utils::String.new(self.class.name).demodulize.downcase
```

We're moving towards the removal of `Hanami::Utils::String` as a type, but we'll keep it as a module to perform string transformations. (See #224 )

That code snippets above should be rewritten as:

```ruby
result = Hanami::Utils::String.underscore(string)
result = Hanami::Utils::String.classify(result)
result
```

or

```ruby
result = Hanami::Utils::String.demodulize(self.class.name)
result = result.downcase
result
```

While these multiple liners do their work, they are not elegant like:

```ruby
Hanami::Utils::String.transform(string, :underscore, :classify)
```

or

```ruby
Hanami::Utils::String.transform(self.class.name, :demodulize, :downcase)
```

## Implementation details

Building a transformation chain is CPU intensive. For this reason they are stored in a thread-safe cache.

This cache has a boost that goes from `1.32x` (basic case) to `3.23x` (more complex cases).

Please have a look at https://gist.github.com/jodosha/abadd8e42aeaa1b0944f5bac3518bac9