### PR TITLE
Fix the singular of exercises (exercise rather than exercis).

### DIFF
--- a/lib/hanami/utils/inflector.rb
+++ b/lib/hanami/utils/inflector.rb
@@ -268,7 +268,8 @@ module Hanami
         'police'      => 'police',
         # fallback
         'hives'       => 'hive',
-        'phases'      => 'phase'
+        'phases'      => 'phase',
+        'exercises'   => 'exercise'
       )
 
       # Block for custom inflection rules.

--- a/spec/support/fixtures/fixtures.rb
+++ b/spec/support/fixtures/fixtures.rb
@@ -608,7 +608,8 @@ TEST_SINGULARS = {
   # https://github.com/hanami/utils/issues/106
   'album'      => 'albums',
   # https://github.com/hanami/utils/issues/217
-  'phase'      => 'phases'
+  'phase'      => 'phases',
+  'exercise'   => 'exercises'
 }.merge(TEST_PLURALS)
 
 require 'hanami/utils/inflector'


### PR DESCRIPTION
I encountered an error with the singularisation rule of `exercises`, so I fixed it by adding an exception and a test for it.