### PR TITLE
logger: creates folder when doesn't exist

### DIFF
--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -5,6 +5,7 @@ require 'hanami/utils/string'
 require 'hanami/utils/json'
 require 'hanami/utils/hash'
 require 'hanami/utils/class_attribute'
+require 'hanami/utils/files'
 
 module Hanami
   # Hanami logger
@@ -453,7 +454,14 @@ module Hanami
     #   logger.info "Hello World"
     #
     #   # => {"app":"Hanami","severity":"DEBUG","time":"2017-03-30T13:57:59Z","message":"Hello World"}
-    def initialize(application_name = nil, *args, stream: $stdout, level: DEBUG, formatter: nil, filter: []) # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Lint/HandleExceptions
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(application_name = nil, *args, stream: $stdout, level: DEBUG, formatter: nil, filter: [])
+      begin
+        Utils::Files.mkdir_p(stream)
+      rescue TypeError
+      end
+
       super(stream, *args)
 
       @level            = _level(level)

--- a/spec/unit/hanami/logger_spec.rb
+++ b/spec/unit/hanami/logger_spec.rb
@@ -182,6 +182,19 @@ RSpec.describe Hanami::Logger do
         end # end IO
       end # end FileSystem
 
+      describe 'file system without folder created' do
+        let(:stream) { Pathname.new('log').join('logfile.log') }
+
+        it 'creates the folder' do
+          logger = Hanami::Logger.new(stream: stream)
+          logger.info('hello world')
+
+          logger.close
+
+          contents = File.read(stream.to_s)
+          expect(contents).to match(/hello world/)
+        end
+      end
       describe 'when StringIO' do
         let(:stream) { StringIO.new }
 


### PR DESCRIPTION
I've noticed when you create a hanami app and add a stream in your development logger, for example a path 'log/development.log', it will fails because log folder isn't created. IMO logger should be in charge of create the path.

What do you think?