### PR TITLE
Reduce memory allocation for PathPrefix#relative!

### DIFF
--- a/lib/hanami/utils/path_prefix.rb
+++ b/lib/hanami/utils/path_prefix.rb
@@ -132,7 +132,7 @@ module Hanami
       # @see #relative
       def relative!
         @string.gsub!(/(?<!:)#{separator * 2}/, separator)
-        @string.sub!(/\A#{separator}/, '')
+        @string[/\A#{separator}|^/] = ''
 
         self
       end


### PR DESCRIPTION
## How I tested it
```ruby
require 'hanami/utils/path_prefix'
require 'memory_profiler'

path_prefix = Hanami::Utils::PathPrefix.new '_posts'
MemoryProfiler.report{ 10_000.times { path_prefix.relative_join('new', '_').to_s } }.pretty_print(to_file: 'path_to_your_log_file')
```

## Before
```
Total allocated: 31580080 bytes (240002 objects)
Total retained:  0 bytes (0 objects)

allocated memory by gem
-----------------------------------
  30780080  utils/lib
    800000  other

allocated memory by file
-----------------------------------
  30780080  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb
    800000  (irb)

allocated memory by location
-----------------------------------
  16200040  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:135
  11300040  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:134
   1680000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:89
    800000  (irb):26
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:82
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:83
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:84
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:88
```

## After
```
Total allocated: 30300080 bytes (240002 objects)
Total retained:  40 bytes (1 objects)

allocated memory by gem
-----------------------------------
  29500080  utils/lib
    800000  other

allocated memory by file
-----------------------------------
  29500080  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb
    800000  (irb)

allocated memory by location
-----------------------------------
  16200040  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:135
  11300040  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:134
    800000  (irb):5
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:82
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:83
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:84
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:88
    400000  /Users/anton/work/repositories/lotus/utils/lib/hanami/utils/path_prefix.rb:89
```

/cc @hanami/core 