### PR TITLE
Make `Hanami::Utils::BasicObject` to be fully compatible with Ruby's `pp` and to be inspected by Pry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Ruby core extentions and class utilities for Hanami
 
 ## v1.0.4 - 2017-10-02
 ### Fixed
+- [Luca Guidi] Make `Hanami::Utils::BasicObject` to be fully compatible with Ruby's `pp` and to be inspected by Pry.
 - [Thiago Kenji Okada] Fix pluralization/singularization for `"release" => "releases"`
 
 ## v1.0.3 - 2017-09-06

--- a/lib/hanami/utils/basic_object.rb
+++ b/lib/hanami/utils/basic_object.rb
@@ -21,7 +21,7 @@ module Hanami
       #
       # @see http://ruby-doc.org/core/Object.html#method-i-inspect
       def inspect
-        "#<#{self.class}:#{'%x' % (__id__ << 1)}#{__inspect}>" # rubocop:disable Style/FormatString
+        "#<#{self.class}:#{'0x0000%x' % (__id__ << 1)}#{__inspect}>" # rubocop:disable Style/FormatString
       end
 
       # Alias for __id__
@@ -37,13 +37,14 @@ module Hanami
 
       # Interface for pp
       #
+      # @param printer [PP] the Pretty Printable printer
       # @return [String] the pretty-printable inspection of the object
       #
       # @since 0.9.0
       #
       # @see https://ruby-doc.org/stdlib/libdoc/pp/rdoc/PP.html
-      def pretty_print(*)
-        inspect
+      def pretty_print(printer)
+        printer.text(inspect)
       end
 
       # Returns true if responds to the given method.

--- a/spec/unit/hanami/utils/basic_object_spec.rb
+++ b/spec/unit/hanami/utils/basic_object_spec.rb
@@ -35,8 +35,19 @@ RSpec.describe Hanami::Utils::BasicObject do
     end
   end
 
-  # See https://github.com/hanami/hanami/issues/629
-  it 'is pretty printable' do
-    pp TestClass.new
+  describe "#pretty_print" do
+    # See https://github.com/hanami/hanami/issues/629
+    it 'is pretty printable' do
+      expect { pp TestClass.new }.to output(/TestClass/).to_stdout
+    end
+
+    # See https://github.com/hanami/utils/issues/234
+    it "outputs the inspection to the given printer" do
+      printer = PP.new
+      subject = TestClass.new
+      subject.pretty_print(printer)
+
+      expect(printer.output).to match(/\A#<TestClass:\w+>\z/)
+    end
   end
 end


### PR DESCRIPTION
![screen shot 2017-10-02 at 18 27 11](https://user-images.githubusercontent.com/5089/31088029-8126b96e-a79f-11e7-88f3-562340213fcb.png)

Fixes #234