### PR TITLE
Introduce `Utils::Hash.deep_serialize` to recursively serialize input into `::Hash`

### DIFF
--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -137,6 +137,46 @@ module Hanami
         end
       end
 
+      # Deep serialize given object into a `Hash`
+      #
+      # Please note that the returning `Hash` will use symbols as keys.
+      #
+      # @param input [#to_hash] the input
+      #
+      # @return [::Hash] the deep serialized hash
+      #
+      # @since 1.1.0
+      #
+      # @example Basic Usage
+      #   require 'hanami/utils/hash'
+      #   require 'ostruct'
+      #
+      #   class Data < OpenStruct
+      #     def to_hash
+      #       to_h
+      #     end
+      #   end
+      #
+      #   input = Data.new("foo" => "bar", baz => [Data.new(hello: "world")])
+      #
+      #   Hanami::Utils::Hash.deep_serialize(input)
+      #     # => {:foo=>"bar", :baz=>[{:hello=>"world"}]}
+      def self.deep_serialize(input) # rubocop:disable Metrics/MethodLength
+        input.to_hash.each_with_object({}) do |(key, value), output|
+          output[key.to_sym] =
+            case value
+            when ->(h) { h.respond_to?(:to_hash) }
+              deep_serialize(value)
+            when Array
+              value.map do |item|
+                item.respond_to?(:to_hash) ? deep_serialize(item) : item
+              end
+            else
+              value
+            end
+        end
+      end
+
       # Initialize the hash
       #
       # @param hash [#to_h] the value we want to use to initialize this instance

--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -1,4 +1,5 @@
 require 'bigdecimal'
+require 'ostruct'
 require 'hanami/utils/hash'
 
 RSpec.describe Hanami::Utils::Hash do
@@ -131,6 +132,38 @@ RSpec.describe Hanami::Utils::Hash do
       result["a"].delete("b")
 
       expect(input).to eq("a" => { "b" => { "c" => 3 } })
+    end
+  end
+
+  describe ".deep_serialize" do
+    let(:input) do
+      klass = Class.new(OpenStruct) do
+        def to_hash
+          to_h
+        end
+      end
+
+      klass.new("foo" => "bar", "baz" => [klass.new(hello: "world")])
+    end
+
+    it "returns a ::Hash" do
+      expect(described_class.deep_serialize(input)).to be_kind_of(::Hash)
+    end
+
+    it "deeply serializes input" do
+      expected = { foo: "bar", baz: [{ hello: "world" }] }
+      actual = described_class.deep_serialize(input)
+
+      expect(actual).to eq(expected)
+    end
+
+    it "uses symbols as keys" do
+      output = described_class.deep_serialize(input)
+
+      expect(output).to be_any
+      output.each_key do |key|
+        expect(key).to be_kind_of(::Symbol)
+      end
     end
   end
 


### PR DESCRIPTION
The feature:

```ruby
require "hanami/utils/hash"
require "ostruct"

class Data < OpenStruct
  def to_hash
    to_h
  end
end

input = Data.new("foo" => "bar", baz => [Data.new(hello: "world")])

Hanami::Utils::Hash.deep_serialize(input)
  # => {:foo=>"bar", :baz=>[{:hello=>"world"}]}
```

---

This feature is needed to make `hanami-controller`'s `BaseParams` and `Params` to be deep serialized into `Hash`, so they can be used directly into `hanami-model` associations.

```ruby
class AuthorRepository < Hanami::Repository
  associations do
    has_many :books
  end

  def create_with_books(data)
    assoc(:books).create(data)
  end
end
```

```ruby
module Web::Controllers::Authors
  class Create
    include Web::Action

    def call(params)
      # This doesn't work as of Hanami 1.0, but it should.
      AuthorRepository.new.create_with_books(params)

      # The actual workaround to make it to work with Hanami 1.0 is:
      AuthorRepository.new.create_with_books(params.to_hash)
    end
  end
end
```

With this PR we can enhance `hanami-model` to deep serialize input into `::Hash` and the first syntax in the example will work.

---

Ref https://github.com/hanami/controller/issues/235
Ref https://github.com/hanami/model/pull/462