### PR TITLE
Fix Files.write behavior

### DIFF
--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -169,7 +169,7 @@ module Hanami
         content = ::File.readlines(path)
         content.unshift("#{line}\n")
 
-        rewrite(path, content)
+        write(path, content, overwrite: true)
       end
 
       # Adds a new line at the bottom of the file
@@ -188,7 +188,7 @@ module Hanami
         content = ::File.readlines(path)
         content << "#{contents}\n"
 
-        rewrite(path, content)
+        write(path, content, overwrite: true)
       end
 
       # Replace first line in `path` that contains `target` with `replacement`.
@@ -207,7 +207,7 @@ module Hanami
         content = ::File.readlines(path)
         content[index(content, path, target)] = "#{replacement}\n"
 
-        rewrite(path, content)
+        write(path, content, overwrite: true)
       end
 
       # Replace last line in `path` that contains `target` with `replacement`.
@@ -226,7 +226,7 @@ module Hanami
         content = ::File.readlines(path)
         content[-index(content.reverse, path, target) - 1] = "#{replacement}\n"
 
-        rewrite(path, content)
+        write(path, content, overwrite: true)
       end
 
       # Inject `contents` in `path` before `target`.
@@ -246,7 +246,7 @@ module Hanami
         i       = index(content, path, target)
 
         content.insert(i, "#{contents}\n")
-        rewrite(path, content)
+        write(path, content, overwrite: true)
       end
 
       # Inject `contents` in `path` after `target`.
@@ -266,7 +266,7 @@ module Hanami
         i       = index(content, path, target)
 
         content.insert(i + 1, "#{contents}\n")
-        rewrite(path, content)
+        write(path, content, overwrite: true)
       end
 
       # Removes line from `path`, matching `target`.
@@ -283,7 +283,7 @@ module Hanami
         i       = index(content, path, target)
 
         content.delete_at(i)
-        rewrite(path, content)
+        write(path, content, overwrite: true)
       end
 
       # Removes `target` block from `path`
@@ -322,7 +322,7 @@ module Hanami
         ending   = starting + index(content[starting..-1], path, closing)
 
         content.slice!(starting..ending)
-        rewrite(path, content)
+        write(path, content, overwrite: true)
 
         remove_block(path, target) if match?(content, target)
       end

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -1,6 +1,6 @@
 require "pathname"
 require "fileutils"
-require 'hanami/utils/deprecation'
+require "hanami/utils/deprecation"
 
 module Hanami
   module Utils
@@ -8,16 +8,6 @@ module Hanami
     #
     # @since 1.1.0
     module Files # rubocop:disable Metrics/ModuleLength
-      # An error that will be thrown when a file exists,
-      # but we didn't expect that.
-      #
-      # @since x.x.x
-      class FileAlreadyExistsError < ::StandardError
-        def initialize(path)
-          super "File already exists: #{path}"
-        end
-      end
-
       # Creates an empty file for the given path.
       # All the intermediate directories are created.
       # If the path already exists, it doesn't change the contents
@@ -25,27 +15,19 @@ module Hanami
       # @param path [String,Pathname] the path to file
       #
       # @since 1.1.0
-      # rubocop:disable Lint/HandleExceptions:
       def self.touch(path)
-        write(path, "")
-      rescue FileAlreadyExistsError
-        # This is fine, do nothing.
+        mkdir_p(path)
+        FileUtils.touch(path)
       end
-      # rubocop:enable Lint/HandleExceptions:
 
       # Creates a new file for the given path and content.
       # All the intermediate directories are created.
-      # If the path already exists and overwrite is true,
-      # the contents are replaced.
       #
       # @param path [String,Pathname] the path to file
       # @param content [String, Array<String>] the content to write
       #
-      # @raise [FileAlreadyExistsError] if file exists and overwrite is false
-      #
       # @since 1.1.0
-      def self.write(path, *content, overwrite: false)
-        raise FileAlreadyExistsError, path if !overwrite && File.exist?(path)
+      def self.write(path, *content)
         mkdir_p(path)
         open(path, ::File::CREAT | ::File::WRONLY | ::File::TRUNC, *content)
       end
@@ -61,10 +43,10 @@ module Hanami
       # @since 1.1.0
       def self.rewrite(path, *content)
         Hanami::Utils::Deprecation.new(
-          'rewrite is deprecated, please use write and pass overwrite: true'
+          "`.rewrite' is deprecated, please use `.write'"
         )
         raise Errno::ENOENT unless File.exist?(path)
-        write(path, *content, overwrite: true)
+        write(path, *content)
       end
 
       # Copies source into destination.
@@ -74,15 +56,9 @@ module Hanami
       # @param source [String,Pathname] the path to the source file
       # @param destination [String,Pathname] the path to the destination file
       #
-      # @raise [FileAlreadyExistsError] if file exists and overwrite is false
-      #
       # @since 1.1.0
-      def self.cp(source, destination, overwrite: true)
-        if File.exist?(destination)
-          raise FileAlreadyExistsError, destination unless overwrite
-        else
-          mkdir_p(destination)
-        end
+      def self.cp(source, destination)
+        mkdir_p(destination)
         FileUtils.cp(source, destination)
       end
 
@@ -169,7 +145,7 @@ module Hanami
         content = ::File.readlines(path)
         content.unshift("#{line}\n")
 
-        write(path, content, overwrite: true)
+        write(path, content)
       end
 
       # Adds a new line at the bottom of the file
@@ -188,7 +164,7 @@ module Hanami
         content = ::File.readlines(path)
         content << "#{contents}\n"
 
-        write(path, content, overwrite: true)
+        write(path, content)
       end
 
       # Replace first line in `path` that contains `target` with `replacement`.
@@ -207,7 +183,7 @@ module Hanami
         content = ::File.readlines(path)
         content[index(content, path, target)] = "#{replacement}\n"
 
-        write(path, content, overwrite: true)
+        write(path, content)
       end
 
       # Replace last line in `path` that contains `target` with `replacement`.
@@ -226,7 +202,7 @@ module Hanami
         content = ::File.readlines(path)
         content[-index(content.reverse, path, target) - 1] = "#{replacement}\n"
 
-        write(path, content, overwrite: true)
+        write(path, content)
       end
 
       # Inject `contents` in `path` before `target`.
@@ -246,7 +222,7 @@ module Hanami
         i       = index(content, path, target)
 
         content.insert(i, "#{contents}\n")
-        write(path, content, overwrite: true)
+        write(path, content)
       end
 
       # Inject `contents` in `path` after `target`.
@@ -266,7 +242,7 @@ module Hanami
         i       = index(content, path, target)
 
         content.insert(i + 1, "#{contents}\n")
-        write(path, content, overwrite: true)
+        write(path, content)
       end
 
       # Removes line from `path`, matching `target`.
@@ -283,7 +259,7 @@ module Hanami
         i       = index(content, path, target)
 
         content.delete_at(i)
-        write(path, content, overwrite: true)
+        write(path, content)
       end
 
       # Removes `target` block from `path`
@@ -322,7 +298,7 @@ module Hanami
         ending   = starting + index(content[starting..-1], path, closing)
 
         content.slice!(starting..ending)
-        write(path, content, overwrite: true)
+        write(path, content)
 
         remove_block(path, target) if match?(content, target)
       end

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -76,9 +76,15 @@ module Hanami
       # @param source [String,Pathname] the path to the source file
       # @param destination [String,Pathname] the path to the destination file
       #
+      # @raise [FileAlreadyExistsError] if file exists and overwrite is false
+      #
       # @since 1.1.0
-      def self.cp(source, destination)
-        mkdir_p(destination)
+      def self.cp(source, destination, overwrite: true)
+        if File.exist?(destination)
+          raise FileAlreadyExistsError, destination unless overwrite
+        else
+          mkdir_p(destination)
+        end
         FileUtils.cp(source, destination)
       end
 

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -28,7 +28,7 @@ module Hanami
       # @since 1.1.0
       def self.write(path, *content)
         mkdir_p(path)
-        open(path, ::File::CREAT | ::File::WRONLY, *content)
+        open(path, ::File::CREAT | ::File::WRONLY | ::File::APPEND, *content)
       end
 
       # Rewrites the contents of an existing file.

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -25,11 +25,13 @@ module Hanami
       # @param path [String,Pathname] the path to file
       #
       # @since 1.1.0
+      # rubocop:disable Lint/HandleExceptions:
       def self.touch(path)
         write(path, "")
       rescue FileAlreadyExistsError
         # This is fine, do nothing.
       end
+      # rubocop:enable Lint/HandleExceptions:
 
       # Creates a new file for the given path and content.
       # All the intermediate directories are created.

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -43,13 +43,9 @@ module Hanami
       #
       # @since 1.1.0
       def self.write(path, *content, overwrite: false)
-        if File.exist?(path)
-          raise FileAlreadyExistsError, path unless overwrite
-          delete(path)
-        else
-          mkdir_p(path)
-        end
-        open(path, ::File::CREAT | ::File::WRONLY, *content)
+        raise FileAlreadyExistsError, path if !overwrite && File.exist?(path)
+        mkdir_p(path)
+        open(path, ::File::CREAT | ::File::WRONLY | ::File::TRUNC, *content)
       end
 
       # Rewrites the contents of an existing file.

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -52,21 +52,10 @@ RSpec.describe Hanami::Utils::Files do
       expect(path).to have_content(":)")
     end
 
-    it "throws FileAlreadyExists error when not told to overwrite" do
-      path = root.join("write")
-      described_class.write(path, "some words")
-      expect do
-        described_class.write(path, "some other words")
-      end.to raise_error(Hanami::Utils::Files::FileAlreadyExistsError)
-
-      expect(path).to exist
-      expect(path).to have_content("some words")
-    end
-
-    it "overwrites file, when specifically told to" do
+    it "overwrites file when it already exists" do
       path = root.join("write")
       described_class.write(path, "many many many many words")
-      described_class.write(path, "new words", overwrite: true)
+      described_class.write(path, "new words")
 
       expect(path).to exist
       expect(path).to have_content("new words")
@@ -78,7 +67,7 @@ RSpec.describe Hanami::Utils::Files do
       path = root.join("rewrite")
       described_class.write(path, "Hello\nWorld")
       expect { described_class.rewrite(path, "Ciao Mondo") }.to output(
-        include("rewrite is deprecated, please use write and pass overwrite: true - called from: #{__FILE__}:80:in `block")
+        include("`.rewrite' is deprecated, please use `.write' - called from: #{__FILE__}:69:in `block")
       ).to_stderr
     end
 
@@ -149,20 +138,6 @@ RSpec.describe Hanami::Utils::Files do
 
       expect(destination).to exist
       expect(destination).to have_content("the source")
-    end
-
-    it "raises FileAlreadyExists error when overwrite is false" do
-      source = root.join("..", "source")
-      described_class.write(source, "the source")
-
-      destination = root.join("cp")
-      described_class.write(destination, "the destination")
-      expect do
-        described_class.cp(source, destination, overwrite: false)
-      end.to raise_error(Hanami::Utils::Files::FileAlreadyExistsError)
-
-      expect(destination).to exist
-      expect(destination).to have_content("the destination")
     end
   end
 

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -52,13 +52,22 @@ RSpec.describe Hanami::Utils::Files do
       expect(path).to have_content(":)")
     end
 
-    it "replaces previous contents" do
+    it "appends to previous contents (when new string is longer)" do
       path = root.join("write")
-      described_class.write(path, "some words")
+      described_class.write(path, "some words\n")
       described_class.write(path, "some other words")
 
       expect(path).to exist
-      expect(path).to have_content("some other words")
+      expect(path).to have_content("some words\nsome other words")
+    end
+
+    it "appends to previous contents (when new string is shorter)" do
+      path = root.join("write")
+      described_class.write(path, "many many many many words\n")
+      described_class.write(path, "more words")
+
+      expect(path).to exist
+      expect(path).to have_content("many many many many words\nmore words")
     end
   end
 

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -150,6 +150,20 @@ RSpec.describe Hanami::Utils::Files do
       expect(destination).to exist
       expect(destination).to have_content("the source")
     end
+
+    it "raises FileAlreadyExists error when overwrite is false" do
+      source = root.join("..", "source")
+      described_class.write(source, "the source")
+
+      destination = root.join("cp")
+      described_class.write(destination, "the destination")
+      expect do
+        described_class.cp(source, destination, overwrite: false)
+      end.to raise_error(Hanami::Utils::Files::FileAlreadyExistsError)
+
+      expect(destination).to exist
+      expect(destination).to have_content("the destination")
+    end
   end
 
   describe ".mkdir" do

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -52,26 +52,36 @@ RSpec.describe Hanami::Utils::Files do
       expect(path).to have_content(":)")
     end
 
-    it "appends to previous contents (when new string is longer)" do
+    it "throws FileAlreadyExists error when not told to overwrite" do
       path = root.join("write")
-      described_class.write(path, "some words\n")
-      described_class.write(path, "some other words")
+      described_class.write(path, "some words")
+      expect do
+        described_class.write(path, "some other words")
+      end.to raise_error(Hanami::Utils::Files::FileAlreadyExistsError)
 
       expect(path).to exist
-      expect(path).to have_content("some words\nsome other words")
+      expect(path).to have_content("some words")
     end
 
-    it "appends to previous contents (when new string is shorter)" do
+    it "overwrites file, when specifically told to" do
       path = root.join("write")
-      described_class.write(path, "many many many many words\n")
-      described_class.write(path, "more words")
+      described_class.write(path, "many many many many words")
+      described_class.write(path, "new words", overwrite: true)
 
       expect(path).to exist
-      expect(path).to have_content("many many many many words\nmore words")
+      expect(path).to have_content("new words")
     end
   end
 
   describe ".rewrite" do
+    it "is deprecated" do
+      path = root.join("rewrite")
+      described_class.write(path, "Hello\nWorld")
+      expect { described_class.rewrite(path, "Ciao Mondo") }.to output(
+        include("rewrite is deprecated, please use write and pass overwrite: true - called from: #{__FILE__}:80:in `block")
+      ).to_stderr
+    end
+
     it "rewrites an existing file with given contents" do
       path = root.join("rewrite")
       described_class.write(path, "Hello\nWorld")


### PR DESCRIPTION
The comments for `Hanami::Utils::Files.write` says:

```
# If the path already exists, it appends the contents.
```

The method did not do this. Instead, [it replaced the beginning of the file](https://github.com/hanami/cli/issues/22). 

Fixes part of https://github.com/hanami/hanami/issues/855.