### PR TITLE
Modify new interactor's argument list to handle some cases

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -351,18 +351,18 @@ module Hanami
       #   end
       #
       #   Signup.new.call # => NoMethodError
-      def call(*args, **kwargs)
+      def call(*args)
         @__result = ::Hanami::Interactor::Result.new
-        _call(*args, **kwargs) { super }
+        _call(*args) { super }
       end
 
       private
 
       # @api private
       # @since 1.1.0
-      def _call(*args, **kwargs)
+      def _call(*args)
         catch :fail do
-          validate!(*args, **kwargs)
+          validate!(*args)
           yield
         end
 
@@ -370,8 +370,8 @@ module Hanami
       end
 
       # @since 1.1.0
-      def validate!(*args, **kwargs)
-        fail! unless valid?(*args, **kwargs)
+      def validate!(*args)
+        fail! unless valid?(*args)
       end
     end
 

--- a/spec/unit/hanami/interactor_spec.rb
+++ b/spec/unit/hanami/interactor_spec.rb
@@ -113,6 +113,15 @@ class ComplexCall
   end
 end
 
+class CallWithoutKwargs
+  include Hanami::Interactor
+  expose :args
+
+  def call(*args)
+    @args = args
+  end
+end
+
 class LegacyErrorInteractor
   include Hanami::Interactor
   expose :operations
@@ -495,6 +504,23 @@ RSpec.describe Hanami::Interactor do
         result = ComplexCall.new.call('foo', 'bar', baz: 'baz', buzz: 'buzz')
         expect(result.args).to eql(%w[foo bar])
         expect(result.kwargs).to eql(Hash[baz: 'baz', buzz: 'buzz'])
+      end
+
+      it 'handles args without kwargs' do
+        result = CallWithoutKwargs.new.call('foo', 'bar')
+        expect(result.args).to eql(%w[foo bar])
+      end
+
+      it 'handles kwargs without args' do
+        result = ComplexCall.new.call(baz: 'baz', buzz: 'buzz')
+        expect(result.args).to eql(Array[])
+        expect(result.kwargs).to eql(Hash[baz: 'baz', buzz: 'buzz'])
+      end
+
+      it 'handles args with to_hash method' do
+        user = User.new(name: 'Luca')
+        result = CallWithoutKwargs.new.call(user)
+        expect(result.args).to eql(Array[user])
       end
 
       describe 'inheritance' do

--- a/spec/unit/hanami/interactor_spec.rb
+++ b/spec/unit/hanami/interactor_spec.rb
@@ -88,7 +88,7 @@ class Signup
     @force_failure = force_failure
   end
 
-  def call(params)
+  def call(**params)
     @params = params
     @user = User.new(params)
     @user.persist!


### PR DESCRIPTION
Hi, I'm using hanami for my new project, and I love it. Thank you for a cool framework.
I've noticed that new interactor interface (from 1.1) cannot handle some argument patterns.
I propose a solution to handle such cases.

**case 1: no keyword arguments**
In this case, the actual arguments passed to #call is `['foo', 'bar', {}]`
This can be avoided to change #call args to `call(foo, bar, *)` but i think it is not cool 🤔 

```foo_interactor.rb
class FooInteractor
  include Hanami::Interactor
  def call(foo, bar)
  end
end
```

```
[3] pry(main)> interactor = FooInteractor.new
=> #<FooInteractor:0x007f9d2797ef98>
[4] pry(main)> interactor.call('foo', 'bar')
ArgumentError: wrong number of arguments (given 3, expected 2)
from (pry):4:in `call'
```


**case 2: no keyword arguments and an argument with `#to_hash` method**
In this case, the last argument is converted into Hash automatically if it implements `#to_hash`.
Because `Hanami::Entity` implements `#to_hash`, this case may happen often, and makes the behavior unexpected 😢 

```foo_interactor.rb
class FooInteractor
  include Hanami::Interactor
  def call(foo, bar)
    p foo, bar
  end
end

class Foo < Hanami::Entity; end
class Bar < Hanami::Entity; end
```

```
[8] pry(main)> foo = Foo.new(foo: 'foo')
=> #<Foo:0x007fb0513f2380 @attributes={:foo=>"foo"}>
[9] pry(main)> bar = Bar.new(bar: 'bar')
=> #<Bar:0x007fb051369378 @attributes={:bar=>"bar"}>
[10] pry(main)> interactor.call(foo, bar)
#<Foo:0x007fb0513f2380 @attributes={:foo=>"foo"}>
{:bar=>"bar"}
^^^^^^^^^^^^^ Bar is converted into a hash
=> #<Hanami::Interactor::Result:0x00007fb0512db1b8 @success=true @payload={}>
```