### PR TITLE
Introduce Utils::Hash.deep_stringify

### DIFF
--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -89,6 +89,38 @@ module Hanami
         self[:stringify_keys].call(input)
       end
 
+      # Deeply stringify the given hash
+      #
+      # @param input [::Hash] the input
+      #
+      # @return [::Hash] the deep stringified hash
+      #
+      # @since 1.1.1
+      #
+      # @example Basic Usage
+      #   require "hanami/utils/hash"
+      #
+      #   hash = Hanami::Utils::Hash.deep_stringify(foo: "bar", baz: {a: 1})
+      #     # => {"foo"=>"bar", "baz"=>{"a"=>1}}
+      #
+      #   hash.class
+      #     # => Hash
+      def self.deep_stringify(input) # rubocop:disable Metrics/MethodLength
+        input.each_with_object({}) do |(key, value), output|
+          output[key.to_s] =
+            case value
+            when ::Hash
+              deep_stringify(value)
+            when Array
+              value.map do |item|
+                item.is_a?(::Hash) ? deep_stringify(item) : item
+              end
+            else
+              value
+            end
+        end
+      end
+
       # Deep duplicate hash values
       #
       # The output of this function is a shallow duplicate of the input.

--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -78,6 +78,11 @@ RSpec.describe Hanami::Utils::Hash do
       expect(hash3[:key]).to eq(1)
     end
 
+    it "symbolizes arrays of hashes" do
+      hash = described_class.deep_symbolize("books" => [{ "title" => "Hello Ruby" }, { "title" => "Hello Hanami" }])
+      expect(hash).to eq(books: [{ title: "Hello Ruby" }, { title: "Hello Hanami" }])
+    end
+
     it "does't symbolize nested object that responds to to_hash" do
       nested = described_class.deep_symbolize("metadata" => WrappingHash.new("coverage" => 100))
 
@@ -137,6 +142,11 @@ RSpec.describe Hanami::Utils::Hash do
       expect(hash3.keys).to eq(["key"])
 
       expect(hash3["key"]).to eq(1)
+    end
+
+    it "stringifies arrays of hashes" do
+      hash = described_class.deep_stringify(books: [{ title: "Hello Ruby" }, { title: "Hello Hanami" }])
+      expect(hash).to eq("books" => [{ "title" => "Hello Ruby" }, { "title" => "Hello Hanami" }])
     end
 
     it "does't stringify nested object that responds to to_hash" do

--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Hanami::Utils::Hash do
     it "symbolize keys" do
       hash = described_class.deep_symbolize("fub" => "baz")
 
-      expect(hash["fub"]).to be_nil
       expect(hash[:fub]).to eq("baz")
+      expect(hash.key?("fub")).to be(false)
     end
 
     it "doesn't mutate original input" do
@@ -88,6 +88,67 @@ RSpec.describe Hanami::Utils::Hash do
       hash = described_class.deep_symbolize('foo' => ['bar'])
 
       expect(hash[:foo]).to eq(['bar'])
+    end
+  end
+
+  describe ".deep_stringify" do
+    it "returns ::Hash" do
+      hash = described_class.deep_stringify("fub" => "baz")
+
+      expect(hash).to be_kind_of(::Hash)
+    end
+
+    it "stringify keys" do
+      hash = described_class.deep_stringify(fub: "baz")
+
+      expect(hash["fub"]).to eq("baz")
+      expect(hash.key?(:fub)).to be(false)
+    end
+
+    it "doesn't mutate original input" do
+      input = { nested: { key: "value" } }
+      described_class.deep_stringify(input)
+
+      expect(input).to eq(nested: { key: "value" })
+    end
+
+    it "stringifies nested hashes" do
+      hash = described_class.deep_stringify(nested: { key: "value" })
+
+      expect(hash["nested"]).to be_kind_of(::Hash)
+      expect(hash["nested"]["key"]).to eq("value")
+    end
+
+    it "stringifies deep nested hashes" do
+      hash = described_class.deep_stringify(nested1: { nested2: { nested3: { key: 1 } } })
+
+      expect(hash.keys).to eq(["nested1"])
+
+      hash1 = hash["nested1"]
+      expect(hash1).to be_kind_of(::Hash)
+      expect(hash1.keys).to eq(["nested2"])
+
+      hash2 = hash1["nested2"]
+      expect(hash2).to be_kind_of(::Hash)
+      expect(hash2.keys).to eq(["nested3"])
+
+      hash3 = hash2["nested3"]
+      expect(hash3).to be_kind_of(::Hash)
+      expect(hash3.keys).to eq(["key"])
+
+      expect(hash3["key"]).to eq(1)
+    end
+
+    it "does't stringify nested object that responds to to_hash" do
+      nested = described_class.deep_stringify(metadata: WrappingHash.new(coverage: 100))
+
+      expect(nested["metadata"]).to be_kind_of(WrappingHash)
+    end
+
+    it "doesn't try to stringify nested objects" do
+      hash = described_class.deep_stringify(foo: [:bar])
+
+      expect(hash["foo"]).to eq([:bar])
     end
   end
 


### PR DESCRIPTION
Introduces a new utility method: `Hanami::Utils::Hash.deep_stringify` to recursively stringify hashes.

```ruby
require "hanami/utils/hash"

hash = Hanami::Utils::Hash.deep_stringify(a: { b: { c: { d: [:e] }}})
  # => {"a"=>{"b"=>{"c"=>{"d"=>[:e]}}}}
hash.class
  # => Hash (not Hanami::Utils::Hash)
```

---

Closes #241 
Ref #243 