### PR TITLE
Official support for Ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 sudo: false
 cache: bundler
+before_script:
+  - gem update --system
 script: ./script/ci
 rvm:
   - 2.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: ./script/ci
 rvm:
   - 2.4.2
   - 2.3.5
+  - 2.5.0
   - jruby-9.1.13.0
   - ruby-head
   - jruby-head

--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -329,7 +329,7 @@ module Hanami
       #     'bignum'     => 13289301283 ** 2,
       #     'float'      => 1.0,
       #     'complex'    => Complex(0.3),
-      #     'bigdecimal' => BigDecimal.new('12.0001'),
+      #     'bigdecimal' => BigDecimal('12.0001'),
       #     'rational'   => Rational(0.3),
       #     'string'     => 'foo bar',
       #     'hash'       => { a: 1, b: 'two', c: :three },

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -244,7 +244,7 @@ module Hanami
       #   Hanami::Utils::Kernel.Integer("1")                      # => 1
       #   Hanami::Utils::Kernel.Integer(Rational(0.3))            # => 0
       #   Hanami::Utils::Kernel.Integer(Complex(0.3))             # => 0
-      #   Hanami::Utils::Kernel.Integer(BigDecimal.new(12.00001)) # => 12
+      #   Hanami::Utils::Kernel.Integer(BigDecimal(12.00001))     # => 12
       #   Hanami::Utils::Kernel.Integer(176605528590345446089)
       #     # => 176605528590345446089
       #
@@ -311,11 +311,11 @@ module Hanami
       #   Hanami::Utils::Kernel.Integer(input) # => TypeError
       #
       #   # bigdecimal infinity
-      #   input = BigDecimal.new("Infinity")
+      #   input = BigDecimal("Infinity")
       #   Hanami::Utils::Kernel.Integer(input) # => TypeError
       #
       #   # bigdecimal NaN
-      #   input = BigDecimal.new("NaN")
+      #   input = BigDecimal("NaN")
       #   Hanami::Utils::Kernel.Integer(input) # => TypeError
       #
       #   # big rational
@@ -364,7 +364,7 @@ module Hanami
       #   Hanami::Utils::Kernel.BigDecimal("1")                      # => 1
       #   Hanami::Utils::Kernel.BigDecimal(Rational(0.3))            # => 0.3
       #   Hanami::Utils::Kernel.BigDecimal(Complex(0.3))             # => 0.3
-      #   Hanami::Utils::Kernel.BigDecimal(BigDecimal.new(12.00001)) # => 12.00001
+      #   Hanami::Utils::Kernel.BigDecimal(BigDecimal(12.00001))     # => 12.00001
       #   Hanami::Utils::Kernel.BigDecimal(176605528590345446089)
       #     # => 176605528590345446089
       #
@@ -373,7 +373,7 @@ module Hanami
       #
       #   UltimateAnswer = Struct.new(:question) do
       #     def to_d
-      #       BigDecimal.new(42)
+      #       BigDecimal(42)
       #     end
       #   end
       #
@@ -422,7 +422,7 @@ module Hanami
         when ->(a) { a.respond_to?(:to_d) }
           arg.to_d
         else
-          BigDecimal.new(arg)
+          ::Kernel.BigDecimal(arg)
         end
       rescue NoMethodError
         raise TypeError.new "can't convert #{inspect_type_error(arg)}into BigDecimal"
@@ -454,7 +454,7 @@ module Hanami
       #   Hanami::Utils::Kernel.Float("1")                      # => 1.0
       #   Hanami::Utils::Kernel.Float(Rational(0.3))            # => 0.3
       #   Hanami::Utils::Kernel.Float(Complex(0.3))             # => 0.3
-      #   Hanami::Utils::Kernel.Float(BigDecimal.new(12.00001)) # => 12.00001
+      #   Hanami::Utils::Kernel.Float(BigDecimal(12.00001))     # => 12.00001
       #   Hanami::Utils::Kernel.Float(176605528590345446089)
       #     # => 176605528590345446089.0
       #
@@ -493,11 +493,11 @@ module Hanami
       #   Hanami::Utils::Kernel.Float("2.5/1") # => 2.5
       #
       #   # bigdecimal infinity
-      #   input = BigDecimal.new("Infinity")
+      #   input = BigDecimal("Infinity")
       #   Hanami::Utils::Kernel.Float(input) # => Infinity
       #
       #   # bigdecimal NaN
-      #   input = BigDecimal.new("NaN")
+      #   input = BigDecimal("NaN")
       #   Hanami::Utils::Kernel.Float(input) # => NaN
       #
       # @example Unchecked Exceptions
@@ -606,9 +606,9 @@ module Hanami
       #
       #   Hanami::Utils::Kernel.String(Rational(-22))                 # => "-22/1"
       #   Hanami::Utils::Kernel.String(Complex(11, 2))                # => "11+2i"
-      #   Hanami::Utils::Kernel.String(BigDecimal.new(7944.2343, 10)) # => "0.79442343E4"
-      #   Hanami::Utils::Kernel.String(BigDecimal.new('Infinity'))    # => "Infinity"
-      #   Hanami::Utils::Kernel.String(BigDecimal.new('NaN'))         # => "Infinity"
+      #   Hanami::Utils::Kernel.String(BigDecimal(7944.2343, 10))     # => "0.79442343E4"
+      #   Hanami::Utils::Kernel.String(BigDecimal('Infinity'))        # => "Infinity"
+      #   Hanami::Utils::Kernel.String(BigDecimal('NaN'))             # => "Infinity"
       #
       # @example String interface
       #   require 'hanami/utils/kernel'

--- a/spec/unit/hanami/utils/duplicable_spec.rb
+++ b/spec/unit/hanami/utils/duplicable_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hanami::Utils::Duplicable do
       end
 
       it "doesn't dup bigdecimal" do
-        assert_same_duped_object BigDecimal.new(42)
+        assert_same_duped_object BigDecimal(42)
       end
 
       it "doesn't dup bignum" do

--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe Hanami::Utils::Hash do
         'bignum'     => 13_289_301_283**2,
         'float'      => 1.0,
         'complex'    => Complex(0.3),
-        'bigdecimal' => BigDecimal.new('12.0001'),
+        'bigdecimal' => BigDecimal('12.0001'),
         'rational'   => Rational(0.3)
       }
 

--- a/spec/unit/hanami/utils/kernel_spec.rb
+++ b/spec/unit/hanami/utils/kernel_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a bigdecimal is given' do
-        let(:input) { BigDecimal.new('12.0001') }
+        let(:input) { BigDecimal('12.0001') }
 
         it 'returns an bignum' do
           expect(@result).to eq 12
@@ -632,7 +632,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a bigdecimal infinity is given' do
-        let(:input) { BigDecimal.new('Infinity') }
+        let(:input) { BigDecimal('Infinity') }
 
         it 'raises error' do
           expect { Hanami::Utils::Kernel.Integer(input) }.to raise_error(TypeError)
@@ -640,7 +640,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a bigdecimal NaN is given' do
-        let(:input) { BigDecimal.new('NaN') }
+        let(:input) { BigDecimal('NaN') }
 
         it 'raises error' do
           expect { Hanami::Utils::Kernel.Integer(input) }.to raise_error(TypeError)
@@ -712,7 +712,7 @@ RSpec.describe Hanami::Utils::Kernel do
       before do
         PersonFavDecimalNumber = Struct.new(:name) do
           def to_d
-            BigDecimal.new(Rational(23).to_s)
+            BigDecimal(Rational(23).to_s)
           end
         end
 
@@ -727,7 +727,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { 1 }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new(1)
+          expect(@result).to eq BigDecimal(1)
         end
       end
 
@@ -735,7 +735,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { 1.2 }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new('1.2')
+          expect(@result).to eq BigDecimal('1.2')
         end
       end
 
@@ -743,7 +743,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { '23' }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new(23)
+          expect(@result).to eq BigDecimal(23)
         end
       end
 
@@ -751,7 +751,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { '23.1' }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new('23.1')
+          expect(@result).to eq BigDecimal('23.1')
         end
       end
 
@@ -759,7 +759,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { 0o11 }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new(9)
+          expect(@result).to eq BigDecimal(9)
         end
       end
 
@@ -767,7 +767,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { 0xf5 }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new(245)
+          expect(@result).to eq BigDecimal(245)
         end
       end
 
@@ -775,15 +775,15 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { 13_289_301_283**2 }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new(176_605_528_590_345_446_089)
+          expect(@result).to eq BigDecimal(176_605_528_590_345_446_089)
         end
       end
 
       describe 'when a bigdecimal is given' do
-        let(:input) { BigDecimal.new('12.0001') }
+        let(:input) { BigDecimal('12.0001') }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new('12.0001')
+          expect(@result).to eq BigDecimal('12.0001')
         end
       end
 
@@ -791,7 +791,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { Complex(758.3, 0) }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new('758.3')
+          expect(@result).to eq BigDecimal('758.3')
         end
       end
 
@@ -799,7 +799,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { Complex(0.3) }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new('0.3')
+          expect(@result).to eq BigDecimal('0.3')
         end
       end
 
@@ -807,7 +807,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { '2.5/1' }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new('2.5')
+          expect(@result).to eq BigDecimal('2.5')
         end
       end
 
@@ -815,7 +815,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { Rational(0.3) }
 
         it 'returns an BigDecimal' do
-          expect(@result).to eq BigDecimal.new(input.to_s)
+          expect(@result).to eq BigDecimal(input.to_s)
         end
       end
 
@@ -823,7 +823,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { '2/3' }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new('2/3')
+          expect(@result).to eq BigDecimal('2/3')
         end
       end
 
@@ -846,10 +846,10 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a BigDecimal Infinity is given' do
-        let(:input) { BigDecimal.new('Infinity') }
+        let(:input) { BigDecimal('Infinity') }
 
         it 'returns the BigDecimal Infinity representation' do
-          expect(@result).to eq BigDecimal.new('Infinity')
+          expect(@result).to eq BigDecimal('Infinity')
         end
       end
 
@@ -857,7 +857,7 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { PersonFavDecimalNumber.new('Luca') }
 
         it 'returns a BigDecimal' do
-          expect(@result).to eq BigDecimal.new(23)
+          expect(@result).to eq BigDecimal(23)
         end
       end
     end
@@ -871,7 +871,7 @@ RSpec.describe Hanami::Utils::Kernel do
         end
       else
         it 'returns an BigDecimal' do
-          expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal.new(0)
+          expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal(0)
         end
       end
     end
@@ -880,25 +880,25 @@ RSpec.describe Hanami::Utils::Kernel do
       let(:input) { '23.0 street' }
 
       it 'returns an BigDecimal' do
-        expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal.new(23)
+        expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal(23)
       end
     end
 
     # Bug: https://github.com/hanami/utils/issues/140
     describe 'when a negative bigdecimal is given' do
-      let(:input) { BigDecimal.new('-12.0001') }
+      let(:input) { BigDecimal('-12.0001') }
 
       it 'returns a BigDecimal' do
-        expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal.new('-12.0001')
+        expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal('-12.0001')
       end
     end
 
     # Bug: https://github.com/hanami/utils/issues/140
     describe 'when the big decimal is less than 1 with high precision' do
-      let(:input) { BigDecimal.new('0.0001') }
+      let(:input) { BigDecimal('0.0001') }
 
       it 'returns a BigDecimal' do
-        expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal.new('0.0001')
+        expect(Hanami::Utils::Kernel.BigDecimal(input)).to eq BigDecimal('0.0001')
       end
     end
 
@@ -1054,7 +1054,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a bigdecimal is given' do
-        let(:input) { BigDecimal.new('12.0001') }
+        let(:input) { BigDecimal('12.0001') }
 
         it 'returns a float' do
           expect(@result).to be_kind_of(Float)
@@ -1063,7 +1063,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a bigdecimal infinity is given' do
-        let(:input) { BigDecimal.new('Infinity') }
+        let(:input) { BigDecimal('Infinity') }
 
         it 'returns Infinity' do
           expect(@result).to be_kind_of(Float)
@@ -1072,7 +1072,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a bigdecimal NaN is given' do
-        let(:input) { BigDecimal.new('NaN') }
+        let(:input) { BigDecimal('NaN') }
 
         it 'returns NaN' do
           expect(@result).to be_kind_of(Float)
@@ -1349,7 +1349,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a big decimal is given' do
-        let(:input) { BigDecimal.new(7944.2343, 10) }
+        let(:input) { BigDecimal(7944.2343, 10) }
 
         if RUBY_VERSION >= '2.4'
           it 'returns the string representation' do
@@ -1363,7 +1363,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a big decimal infinity is given' do
-        let(:input) { BigDecimal.new('Infinity') }
+        let(:input) { BigDecimal('Infinity') }
 
         it 'returns the string representation' do
           expect(@result).to eq 'Infinity'
@@ -1371,7 +1371,7 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a big decimal NaN is given' do
-        let(:input) { BigDecimal.new('NaN') }
+        let(:input) { BigDecimal('NaN') }
 
         it 'returns the string representation' do
           expect(@result).to eq 'NaN'


### PR DESCRIPTION
This PR also removes the usage of `BigDecimal.new` in favor of `Kernel.BigDecimal`, as suggested by Ruby 2.5.0 warnings.