### PR TITLE
Colored output

### DIFF
--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -723,6 +723,48 @@ module Hanami
       def respond_to_missing?(m, include_private = false)
         @string.respond_to?(m, include_private)
       end
+
+      # Colorize output
+      # 8 colours available: black, red, green, yellow, blue, magenta, cyan, and gray
+      #
+      # @api private
+      # @since 1.2.beta1
+
+      def colorize(color_code)
+        "\e[#{color_code}m#{self}\e[0m"
+      end
+
+      def black
+        colorize(30)
+      end
+
+      def red
+        colorize(31)
+      end
+
+      def green
+        colorize(32)
+      end
+
+      def yellow
+        colorize(33)
+      end
+
+      def blue
+        colorize(34)
+      end
+
+      def magenta
+        colorize(35)
+      end
+
+      def cyan
+        colorize(36)
+      end
+
+      def gray
+        colorize(37)
+      end
     end
   end
 end

--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -74,6 +74,21 @@ module Hanami
       # @api private
       CLASSIFY_WORD_SEPARATOR = /#{CLASSIFY_SEPARATOR}|#{NAMESPACE_SEPARATOR}|#{UNDERSCORE_SEPARATOR}|#{DASHERIZE_SEPARATOR}/
 
+      # Escape codes for terminals to output strings in colors
+      #
+      # @since x.x.x
+      # @api private
+      COLORS = Hash[
+        black:   30,
+        red:     31,
+        green:   32,
+        yellow:  33,
+        blue:    34,
+        magenta: 35,
+        cyan:    36,
+        gray:    37,
+      ].freeze
+
       @__transformations__ = Concurrent::Map.new
 
       extend Transproc::Registry
@@ -725,45 +740,20 @@ module Hanami
       end
 
       # Colorize output
-      # 8 colours available: black, red, green, yellow, blue, magenta, cyan, and gray
+      # 8 colors available: black, red, green, yellow, blue, magenta, cyan, and gray
       #
       # @api private
-      # @since 1.2.beta1
-
-      def colorize(color_code)
-        "\e[#{color_code}m#{self}\e[0m"
+      # @since x.x.x
+      def self.colorize(input, color:)
+        "\e[#{color_code(color)}m#{input}\e[0m"
       end
 
-      def black
-        colorize(30)
-      end
-
-      def red
-        colorize(31)
-      end
-
-      def green
-        colorize(32)
-      end
-
-      def yellow
-        colorize(33)
-      end
-
-      def blue
-        colorize(34)
-      end
-
-      def magenta
-        colorize(35)
-      end
-
-      def cyan
-        colorize(36)
-      end
-
-      def gray
-        colorize(37)
+      # Helper method to translate between color names and terminal escape codes
+      #
+      # @api private
+      # @since x.x.x
+      def self.color_code(name)
+        COLORS.fetch(name)
       end
     end
   end

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -823,4 +823,46 @@ RSpec.describe Hanami::Utils::String do
         .to raise_error(NoMethodError, exception_message)
     end
   end
+
+  describe '.colorize' do
+    it "returns a string wrapped with black's code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :black)
+      expect(result).to eq("\e[30mSakura\e[0m")
+    end
+
+    it "returns a string wrapped with red's code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :red)
+      expect(result).to eq("\e[31mSakura\e[0m")
+    end
+
+    it "returns a string wrapped with green's code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :green)
+      expect(result).to eq("\e[32mSakura\e[0m")
+    end
+
+    it "returns a string wrapped with yellow's code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :yellow)
+      expect(result).to eq("\e[33mSakura\e[0m")
+    end
+
+    it "returns a string wrapped with blue's code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :blue)
+      expect(result).to eq("\e[34mSakura\e[0m")
+    end
+
+    it "returns a string wrapped with magenta's escape code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :magenta)
+      expect(result).to eq("\e[35mSakura\e[0m")
+    end
+
+    it "returns a string wrapped with cyan's escape code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :cyan)
+      expect(result).to eq("\e[36mSakura\e[0m")
+    end
+
+    it "returns a string wrapped with gray's color code" do
+      result = Hanami::Utils::String.colorize('Sakura', color: :gray)
+      expect(result).to eq("\e[37mSakura\e[0m")
+    end
+  end
 end


### PR DESCRIPTION
This is a first implementation to render colored output in logs. This common work can be used both in `Hanami::CLI` and `Hanami::Utils::Logger`.

What do you think, @hanami/core? Any suggestions on the point we got so far? 

Lots of thanks for the guidance and pairing to @cllns, very nice to have done this!