### PR TITLE
Make Hanami::Interactor::Result inherit from ::Object

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -10,7 +10,7 @@ module Hanami
     # Result of an operation
     #
     # @since 0.3.5
-    class Result < Utils::BasicObject
+    class Result
       # Concrete methods
       #
       # @since 0.3.5
@@ -128,12 +128,6 @@ module Hanami
       def respond_to_missing?(method_name, _include_all)
         method_name = method_name.to_sym
         METHODS[method_name] || @payload.key?(method_name)
-      end
-
-      # @since 0.3.5
-      # @api private
-      def __inspect
-        " @success=#{@success} @payload=#{@payload.inspect}"
       end
     end
 

--- a/lib/hanami/utils/basic_object.rb
+++ b/lib/hanami/utils/basic_object.rb
@@ -3,43 +3,7 @@ module Hanami
     # BasicObject
     #
     # @since 0.3.5
-    class BasicObject < ::BasicObject
-      # Return the class for debugging purposes.
-      #
-      # @since 0.3.5
-      #
-      # @see http://ruby-doc.org/core/Object.html#method-i-class
-      def class
-        (class << self; self; end).superclass
-      end
-
-      # Bare minimum inspect for debugging purposes.
-      #
-      # @return [String] the inspect string
-      #
-      # @since 0.3.5
-      #
-      # @see http://ruby-doc.org/core/Object.html#method-i-inspect
-      #
-      # rubocop:disable Style/FormatString
-      # rubocop:disable Style/FormatStringToken
-      def inspect
-        "#<#{self.class}:#{'0x0000%x' % (__id__ << 1)}#{__inspect}>"
-      end
-      # rubocop:enable Style/FormatStringToken
-      # rubocop:enable Style/FormatString
-
-      # Alias for __id__
-      #
-      # @return [Fixnum] the object id
-      #
-      # @since 0.9.0
-      #
-      # @see http://ruby-doc.org/core/Object.html#method-i-object_id
-      def object_id
-        __id__
-      end
-
+    class BasicObject
       # Interface for pp
       #
       # @param printer [PP] the Pretty Printable printer
@@ -52,17 +16,6 @@ module Hanami
         printer.text(inspect)
       end
 
-      # Returns true if responds to the given method.
-      #
-      # @return [TrueClass,FalseClass] the result of the check
-      #
-      # @since 0.3.5
-      #
-      # @see http://ruby-doc.org/core-2.2.1/Object.html#method-i-respond_to-3F
-      def respond_to?(method_name, include_all = false)
-        respond_to_missing?(method_name, include_all)
-      end
-
       private
 
       # Must be overridden by descendants
@@ -71,11 +24,6 @@ module Hanami
       # @api private
       def respond_to_missing?(_method_name, _include_all)
         ::Kernel.raise ::NotImplementedError
-      end
-
-      # @since 0.3.5
-      # @api private
-      def __inspect
       end
     end
   end

--- a/lib/hanami/utils/basic_object.rb
+++ b/lib/hanami/utils/basic_object.rb
@@ -3,7 +3,43 @@ module Hanami
     # BasicObject
     #
     # @since 0.3.5
-    class BasicObject
+    class BasicObject < ::BasicObject
+      # Return the class for debugging purposes.
+      #
+      # @since 0.3.5
+      #
+      # @see http://ruby-doc.org/core/Object.html#method-i-class
+      def class
+        (class << self; self; end).superclass
+      end
+
+      # Bare minimum inspect for debugging purposes.
+      #
+      # @return [String] the inspect string
+      #
+      # @since 0.3.5
+      #
+      # @see http://ruby-doc.org/core/Object.html#method-i-inspect
+      #
+      # rubocop:disable Style/FormatString
+      # rubocop:disable Style/FormatStringToken
+      def inspect
+        "#<#{self.class}:#{'0x0000%x' % (__id__ << 1)}#{__inspect}>"
+      end
+      # rubocop:enable Style/FormatStringToken
+      # rubocop:enable Style/FormatString
+
+      # Alias for __id__
+      #
+      # @return [Fixnum] the object id
+      #
+      # @since 0.9.0
+      #
+      # @see http://ruby-doc.org/core/Object.html#method-i-object_id
+      def object_id
+        __id__
+      end
+
       # Interface for pp
       #
       # @param printer [PP] the Pretty Printable printer
@@ -16,6 +52,17 @@ module Hanami
         printer.text(inspect)
       end
 
+      # Returns true if responds to the given method.
+      #
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @since 0.3.5
+      #
+      # @see http://ruby-doc.org/core-2.2.1/Object.html#method-i-respond_to-3F
+      def respond_to?(method_name, include_all = false)
+        respond_to_missing?(method_name, include_all)
+      end
+
       private
 
       # Must be overridden by descendants
@@ -24,6 +71,11 @@ module Hanami
       # @api private
       def respond_to_missing?(_method_name, _include_all)
         ::Kernel.raise ::NotImplementedError
+      end
+
+      # @since 0.3.5
+      # @api private
+      def __inspect
       end
     end
   end


### PR DESCRIPTION
Simply inherit `BasicObject` from stdlib's `Object` instead of picking methods from it.

Closes: https://github.com/hanami/utils/issues/252