### PR TITLE
Implement PoC for with_context method

### DIFF
--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -165,6 +165,16 @@ module Hanami
       # @api private
       attr_writer :hash_filter
 
+      # @since x.x.x
+      # @api private
+      attr_writer :context
+
+      # @since x.x.x
+      # @api private
+      def context
+        @context ||= {}
+      end
+
       # @since 0.5.0
       # @api private
       #
@@ -173,7 +183,8 @@ module Hanami
         _format({
           app:      application_name,
           severity: severity,
-          time:     time
+          time:     time,
+          **context
         }.merge(
           _message_hash(msg)
         ))
@@ -492,6 +503,12 @@ module Hanami
     # @since 0.8.0
     def close
       super unless [STDOUT, $stdout].include?(@stream)
+    end
+
+    def with_context(context)
+      @formatter.context.merge!(context)
+      yield if block_given?
+      context.each_key { |key| @formatter.context.delete(key) }
     end
 
     private


### PR DESCRIPTION
Just a proof of concept for https://github.com/hanami/utils/issues/250

------------

It's just a idea but, what if we call `with_context` method with a block? For example, it will be awesome for wrapping all action:

```ruby
class LoggerMiddleware
  def call(env)
    logger.with_context(uuid: SequreRand.uuid) do
      @app.call(env)
    end
  end
end

class Books::Index
  def call(params)
    logger.info 'good request' # => [Hanami] [INFO] [2018-03-01 00:37:23 +0300] uuid="..." good request
    # ...
  end
end
```

Also, we can wrap workers, rake tasks, interactors or other places with specific context

------

I created simple and ugly PR just for proof idea. Also, I created a local file with this code:

```ruby
require 'hanami/logger'

class Test
  attr_reader :logger

  def initialize(logger: nil)
    @logger = logger
  end

  def call(payload = {})
    logger.debug 'from test object'
    logger.debug payload
  end
end


logger = Hanami::Logger.new
test = Test.new(logger: logger)

logger.info 'hello'
test.call(a: 1, b: 2)

logger.with_context(uuid: '123') do
  logger.info 'hello with context'
  test.call(a: 1, b: 2)

  logger.with_context(other: 'test') do
    logger.info 'hello with nested context'
    test.call(a: 1, b: 2)
  end

  logger.info 'bye with context'
  test.call(a: 1, b: 2)
end

logger.info 'bye'
test.call(a: 1, b: 2)
```

Anf got this result:
![screenshot 2018-03-01 00 49 17](https://user-images.githubusercontent.com/1147484/36814996-612fc4fa-1cea-11e8-96b2-d7105fa4f785.jpeg)

But now I have some problems with I need to solve:

- [ ] Tread safe code
- [ ] Specs

--------------

WDYT @hanami/core? 