### PR TITLE
Colorize logger severity

### DIFF
--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -140,6 +140,17 @@ module Hanami
       "unknown" => UNKNOWN
     ].freeze
 
+    # @since 1.2.0
+    # @api private
+    def self.level(level)
+      case level
+      when DEBUG..UNKNOWN
+        level
+      else
+        LEVELS.fetch(level.to_s.downcase, DEBUG)
+      end
+    end
+
     # @since 0.5.0
     # @api private
     attr_writer :application_name
@@ -329,12 +340,7 @@ module Hanami
     # @since 0.8.0
     # @api private
     def _level(level)
-      case level
-      when DEBUG..UNKNOWN
-        level
-      else
-        LEVELS.fetch(level.to_s.downcase, DEBUG)
-      end
+      self.class.level(level)
     end
 
     # @since 1.2.0

--- a/lib/hanami/logger/colorizer.rb
+++ b/lib/hanami/logger/colorizer.rb
@@ -52,16 +52,24 @@ module Hanami
 
       private
 
-      # The colors defined for the four parts of the log message
-      #
-      # These can be overridden, keeping the name keys, with acceptable values
-      # being any from Hanami::Utils::ShellColor::COLORS
+      # The colors defined for the three parts of the log message
       #
       # @since 1.2.0
+      # @api private
       COLORS = ::Hash[
         app:      :blue,
-        severity: :gray,
         datetime: :cyan,
+      ].freeze
+
+      # @since 1.2.0
+      # @api private
+      LEVELS = ::Hash[
+        Hanami::Logger::DEBUG   => :cyan,
+        Hanami::Logger::INFO    => :magenta,
+        Hanami::Logger::WARN    => :yellow,
+        Hanami::Logger::ERROR   => :red,
+        Hanami::Logger::FATAL   => :red,
+        Hanami::Logger::UNKNOWN => :blue,
       ].freeze
 
       attr_reader :colors
@@ -75,16 +83,7 @@ module Hanami
       # @since 1.2.0
       # @api private
       def severity(input)
-        color = case Hanami::Logger.level(input)
-                when Hanami::Logger::INFO                         then :magenta
-                when Hanami::Logger::WARN                         then :yellow
-                when Hanami::Logger::DEBUG                        then :cyan
-                when Hanami::Logger::UNKNOWN                      then :blue
-                when Hanami::Logger::ERROR, Hanami::Logger::FATAL then :red
-                else
-                  colors.fetch(:severity, nil)
-                end
-
+        color = LEVELS.fetch(Hanami::Logger.level(input), :gray)
         colorize(input, color: color)
       end
 

--- a/lib/hanami/logger/colorizer.rb
+++ b/lib/hanami/logger/colorizer.rb
@@ -60,7 +60,7 @@ module Hanami
       # @since 1.2.0
       COLORS = ::Hash[
         app:      :blue,
-        severity: :magenta,
+        severity: :gray,
         datetime: :cyan,
       ].freeze
 
@@ -75,7 +75,17 @@ module Hanami
       # @since 1.2.0
       # @api private
       def severity(input)
-        colorize(input, color: colors.fetch(:severity, nil))
+        color = case Hanami::Logger.level(input)
+                when Hanami::Logger::INFO                         then :magenta
+                when Hanami::Logger::WARN                         then :yellow
+                when Hanami::Logger::DEBUG                        then :cyan
+                when Hanami::Logger::UNKNOWN                      then :blue
+                when Hanami::Logger::ERROR, Hanami::Logger::FATAL then :red
+                else
+                  colors.fetch(:severity, nil)
+                end
+
+        colorize(input, color: color)
       end
 
       # @since 1.2.0

--- a/spec/unit/hanami/logger_spec.rb
+++ b/spec/unit/hanami/logger_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Hanami::Logger do
                 end
 
                 expect(output).to include(
-                  "[\e[31mHanami\e[0m] [INFO] ["
+                  "[\e[31mHanami\e[0m] [\e[35mINFO\e[0m] ["
                 )
               end
 


### PR DESCRIPTION
Colorize logger severity with the following scheme:

  * UNKNOWN => blue
  * DEBUG => cyan
  * INFO => magenta
  * WARN => yellow
  * ERROR, FATAL => red

![colorize-logger-severity](https://user-images.githubusercontent.com/5089/38366307-9d3bd1da-38df-11e8-8124-6da832faf68b.png)
