### PR TITLE
Bump required_ruby_version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 # Please keep AllCops, Bundler, Style, Metrics groups and then order cops
 # alphabetically
+AllCops:
+  TargetRubyVersion: 2.4
 inherit_from:
   - https://raw.githubusercontent.com/hanami/devtools/master/.rubocop.yml
 Naming/HeredocDelimiterNaming:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_script:
 script: ./script/ci
 rvm:
   - 2.4.2
-  - 2.3.5
   - 2.5.0
   - jruby-9.1.13.0
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: ./script/ci
 rvm:
   - 2.4.2
   - 2.5.0
-  - jruby-9.1.13.0
+  - jruby-9.1.16.0
   - ruby-head
   - jruby-head
 

--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_dependency 'transproc',       '~> 1.0'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -294,7 +294,7 @@ module Hanami
         starting = index(content, path, target)
         line     = content[starting]
         size     = line[/\A[[:space:]]*/].bytesize
-        closing  = (" " * size) + (target =~ /{/ ? '}' : 'end')
+        closing  = (" " * size) + (target.match?(/{/) ? '}' : 'end')
         ending   = starting + index(content[starting..-1], path, closing)
 
         content.slice!(starting..ending)


### PR DESCRIPTION
This pull request is leading up to a fix for hanami/hanami#921

- Add TargetRubyVersion to rubocop config to silence warnings about
mismatch between rubocop config and gemspec.
- Switch =~ usage to match? per rubocop in files.remove_block