### PR TITLE
Fixnum is deprecated and warning was showing

### DIFF
--- a/spec/unit/hanami/utils/kernel_spec.rb
+++ b/spec/unit/hanami/utils/kernel_spec.rb
@@ -1491,13 +1491,13 @@ RSpec.describe Hanami::Utils::Kernel do
       end
 
       describe 'when a class is given' do
-        let(:input) { Fixnum } # rubocop:disable Lint/UnifiedInteger
-
         if RUBY_VERSION >= '2.4'
+          let(:input) { Integer }
           it 'returns the string representation' do
             expect(@result).to eq 'Integer'
           end
         else
+          let(:input) { Fixnum } # rubocop:disable Lint/UnifiedInteger
           it 'returns the string representation' do
             expect(@result).to eq 'Fixnum'
           end


### PR DESCRIPTION
During ./script/ci warning was shown:

	/home/wolf/devel/hanami-utils/spec/unit/hanami/utils/kernel_spec.rb:1494: warning: constant ::Fixnum is deprecated

This change fixes it.