### PR TITLE
add Utils::IO::silence_stderr

### DIFF
--- a/lib/hanami/utils/io.rb
+++ b/lib/hanami/utils/io.rb
@@ -32,6 +32,32 @@ module Hanami
       ensure
         $VERBOSE = old_verbose
       end
+
+      # @yield the block of code that generates error output.
+      #
+      # @return [void]
+      #
+      # @since x.x.x
+      #
+      # @example
+      #   require 'hanami/utils/io'
+      #
+      #   class Test
+      #     def speak
+      #       Kernel.warn('hello in here')
+      #     end
+      #   end
+      #
+      #   Hanami::Utils::IO.silence_stderr do
+      #     Test.speak
+      #   end
+      def self.silence_stderr
+        original_stderr = $stderr
+        $stderr = File.open(File::NULL, "w")
+        yield
+      ensure
+        $stderr = original_stderr
+      end
     end
   end
 end

--- a/spec/unit/hanami/utils/io_spec.rb
+++ b/spec/unit/hanami/utils/io_spec.rb
@@ -2,6 +2,10 @@ require 'hanami/utils/io'
 
 class IOTest
   TEST_CONSTANT = 'initial'.freeze
+
+  def self.print_error
+    Kernel.warn('Hey look at me!')
+  end
 end
 
 RSpec.describe Hanami::Utils::IO do
@@ -10,6 +14,16 @@ RSpec.describe Hanami::Utils::IO do
       expect do
         Hanami::Utils::IO.silence_warnings do
           IOTest::TEST_CONSTANT = 'redefined'.freeze
+        end
+      end.to output(eq('')).to_stderr
+    end
+  end
+
+  describe '.silence_stderr' do
+    it 'sets $stderr to File::Null' do
+      expect do
+        Hanami::Utils::IO.silence_stderr do
+          IOTest.print_error
         end
       end.to output(eq('')).to_stderr
     end


### PR DESCRIPTION
@jodosha 

Following @AlfonsoUceda advice I added `Utils::IO.silence_stderr`

Maybe we could look for a more general method like:

```ruby
def self.silence_output(output = $stderr)
  original_output = output
  output = File.open(File::NULL, "w")
  yield
ensure
  output = original_output
end
```