### PR TITLE
Update settings for code quality services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             ./script/ci
   "jruby-9.1":
     docker:
-       - image: circleci/jruby:9.1.17.0
+       - image: circleci/jruby:9.1-jdk
     working_directory: ~/hanami-utils
     steps:
       - checkout

--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,0 +1,1 @@
+debug.fullTrace=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ before_script:
   - gem update --system
 script: ./script/ci
 rvm:
-  - 2.4.2
-  - 2.3.5
-  - 2.5.0
-  - jruby-9.1.13.0
+  - 2.4.4
+  - 2.3.7
+  - 2.5.1
+  - jruby-9.1.9.0
   - ruby-head
   - jruby-head
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-unless ENV['TRAVIS']
+unless ENV['CI']
   gem 'byebug', require: false, platforms: :mri if RUBY_VERSION >= '2.2.0'
   gem 'yard',   require: false
 end
@@ -17,4 +17,4 @@ end
 gem 'gson', '>= 0.6', require: false, platforms: :jruby
 
 gem 'rubocop', '~> 0.57.0', require: false
-gem 'coveralls', require: false
+gem 'codecov', require: false, group: :test

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Ruby core extensions and class utilities for [Hanami](http://hanamirb.org)
 
 ## Status
 
-[![Gem Version](http://img.shields.io/gem/v/hanami-utils.svg)](https://badge.fury.io/rb/hanami-utils)
-[![Build Status](http://img.shields.io/travis/hanami/utils/master.svg)](https://travis-ci.org/hanami/utils?branch=master)
-[![Coverage](http://img.shields.io/coveralls/hanami/utils/master.svg)](https://coveralls.io/r/hanami/utils)
-[![Code Climate](http://img.shields.io/codeclimate/github/hanami/utils.svg)](https://codeclimate.com/github/hanami/utils)
-[![Dependencies](http://img.shields.io/gemnasium/hanami/utils.svg)](https://gemnasium.com/hanami/utils)
+[![Gem Version](https://badge.fury.io/rb/hanami-utils.svg)](https://badge.fury.io/rb/hanami-utils)
+[![TravisCI](https://travis-ci.org/hanami/utils.svg?branch=master)](https://travis-ci.org/hanami/utils)
+[![CircleCI](https://circleci.com/gh/hanami/utils/tree/master.svg?style=svg)](https://circleci.com/gh/hanami/utils/tree/master)
+[![Test Coverage](https://codecov.io/gh/hanami/utils/branch/master/graph/badge.svg)](https://codecov.io/gh/hanami/utils)
+[![Depfu](https://badges.depfu.com/badges/a8545fb67cf32a2c75b6227bc0821027/overview.svg)](https://depfu.com/github/hanami/utils?project=Bundler)
 [![Inline Docs](http://inch-ci.org/github/hanami/utils.svg)](http://inch-ci.org/github/hanami/utils)
 
 ## Contact

--- a/Rakefile
+++ b/Rakefile
@@ -9,10 +9,18 @@ namespace :spec do
 
     task.pattern = file_list
   end
+end
 
-  task :coverage do
-    ENV['COVERAGE'] = 'true'
-    Rake::Task['spec:unit'].invoke
+namespace :codecov do
+  desc 'Uploads the latest simplecov result set to codecov.io'
+  task :upload do
+    if ENV['CI']
+      require 'simplecov'
+      require 'codecov'
+
+      formatter = SimpleCov::Formatter::Codecov.new
+      formatter.format(SimpleCov::ResultMerger.merged_result)
+    end
   end
 end
 

--- a/script/ci
+++ b/script/ci
@@ -2,12 +2,18 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+prepare_build() {
+  if [ -d coverage ]; then
+    rm -rf coverage
+  fi
+}
+
 run_code_quality_checks() {
   bundle exec rubocop .
 }
 
 run_unit_tests() {
-  bundle exec rake spec:coverage
+  bundle exec rake spec:unit
 }
 
 run_isolation_tests() {
@@ -26,6 +32,10 @@ run_isolation_tests() {
   done
 }
 
+update_code_coverage() {
+  bundle exec rake codecov:upload
+}
+
 run_isolation_test() {
   local test=$1
 
@@ -41,9 +51,11 @@ run_test() {
 }
 
 main() {
-  run_code_quality_checks &&
+  prepare_build &&
+    run_code_quality_checks &&
     run_unit_tests &&
-    run_isolation_tests
+    run_isolation_tests &&
+    update_code_coverage
 }
 
 main

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,0 +1,8 @@
+if ENV['CI']
+  require 'simplecov'
+
+  SimpleCov.command_name ENV['SIMPLECOV_COMMAND_NAME'] || 'spec:unit'
+  SimpleCov.start do
+    add_filter(/spec/)
+  end
+end

--- a/spec/support/isolation_spec_helper.rb
+++ b/spec/support/isolation_spec_helper.rb
@@ -1,10 +1,13 @@
 require 'rubygems'
 require 'bundler'
-Bundler.setup(:default, :development)
+Bundler.setup(:default, :development, :test)
+
+ENV['SIMPLECOV_COMMAND_NAME'] = "Isolation Tests PID #{$$}"
 
 $LOAD_PATH.unshift 'lib'
 require 'hanami/utils'
 require_relative './rspec'
+require_relative './coverage'
 
 module RSpec
   module Support


### PR DESCRIPTION
Let's try these services for a week.

This PR:

  - [x] Updates broken `Gem version` badge
  - [x] Updates broken `Build status` badge in favor of `TravisCI`
  - [x] Adds a `CircleCI` badge
  - [x] Enable CodeCov for this repository (with a badge)
  - [x] Enables depfu for this repository (with a badge)
  - [x] Removes CodeClimate
  - [x] Removes Gemnasium
  - [x] Removes Coveralls
  - [x] Bumps rubies for TravisCI
  - [x] Fixes JRuby version for CircleCI