### PR TITLE
Custom CI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   "ruby-2.3":
     docker:
-       - image: hanami/ruby:2.3
+       - image: hanami/ruby-2.3
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
             ./script/ci
   "ruby-2.4":
     docker:
-       - image: hanami/ruby:2.4
+       - image: hanami/ruby-2.4
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -56,7 +56,7 @@ jobs:
             ./script/ci
   "ruby-2.5":
     docker:
-       - image: hanami/ruby:2.5
+       - image: hanami/ruby-2.5
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -81,7 +81,7 @@ jobs:
             ./script/ci
   "jruby-9.1":
     docker:
-       - image: hanami/jruby:9.1
+       - image: hanami/jruby-9.1
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -106,7 +106,7 @@ jobs:
             ./script/ci
   "jruby-9.2":
     docker:
-       - image: hanami/jruby:9.2
+       - image: hanami/jruby-9.2
     working_directory: ~/hanami-utils
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   "ruby-2.3":
     docker:
-       - image: circleci/ruby:2.3.7
+       - image: hanami/ruby:2.3
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
             ./script/ci
   "ruby-2.4":
     docker:
-       - image: circleci/ruby:2.4.4
+       - image: hanami/ruby:2.4
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -56,7 +56,7 @@ jobs:
             ./script/ci
   "ruby-2.5":
     docker:
-       - image: circleci/ruby:2.5.1
+       - image: hanami/ruby:2.5
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -81,7 +81,7 @@ jobs:
             ./script/ci
   "jruby-9.1":
     docker:
-       - image: circleci/jruby:9.1-jdk
+       - image: hanami/jruby:9.1
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -106,7 +106,7 @@ jobs:
             ./script/ci
   "jruby-9.2":
     docker:
-       - image: circleci/jruby:9.2.0.0
+       - image: hanami/jruby:9.2
     working_directory: ~/hanami-utils
     steps:
       - checkout

--- a/script/ci
+++ b/script/ci
@@ -8,6 +8,11 @@ prepare_build() {
   fi
 }
 
+print_ruby_version() {
+  echo "Using $(ruby -v)"
+  echo
+}
+
 run_code_quality_checks() {
   bundle exec rubocop .
 }
@@ -52,6 +57,7 @@ run_test() {
 
 main() {
   prepare_build &&
+    print_ruby_version &&
     run_code_quality_checks &&
     run_unit_tests &&
     run_isolation_tests &&


### PR DESCRIPTION
We had no control over the machines/images used for our CI. Even with the recent introduction of CircleCI, they removed `circleci/jruby:9.1.1.13` in favor of `circleci/jruby:9.1-jdk`.

This removal or minor updates to the images can potentially cause sudden CI failures.

---

In order to take control and fix this problem, we can use our own Docker images for CI. See https://github.com/hanami/docker-ci-images

From now on, no sudden image changes that can break the builds. If a new version of Ruby is out, we need to update our own images and restart a build.