### PR TITLE
Bump min_ruby_version to 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 # Please keep AllCops, Bundler, Style, Metrics groups and then order cops
 # alphabetically
+AllCops:
+  TargetRubyVersion: 2.4
 inherit_from:
   - https://raw.githubusercontent.com/hanami/devtools/master/.rubocop.yml
 Naming/HeredocDelimiterNaming:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_script:
 script: ./script/ci
 rvm:
   - 2.4.4
-  - 2.3.7
   - 2.5.1
   - jruby-9.2.0.0
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.4.4
   - 2.3.7
   - 2.5.1
-  - jruby-9.1.9.0
+  - jruby-9.2.0.0
   - ruby-head
   - jruby-head
 

--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_dependency 'transproc',       '~> 1.0'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -327,7 +327,7 @@ module Hanami
         starting = index(content, path, target)
         line     = content[starting]
         size     = line[/\A[[:space:]]*/].bytesize
-        closing  = (" " * size) + (target.match(/{/) ? '}' : 'end')
+        closing  = (" " * size) + (target.match?(/{/) ? '}' : 'end')
         ending   = starting + index(content[starting..-1], path, closing)
 
         content.slice!(starting..ending)

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -327,7 +327,7 @@ module Hanami
         starting = index(content, path, target)
         line     = content[starting]
         size     = line[/\A[[:space:]]*/].bytesize
-        closing  = (" " * size) + (target =~ /{/ ? '}' : 'end')
+        closing  = (" " * size) + (target.match(/{/) ? '}' : 'end')
         ending   = starting + index(content[starting..-1], path, closing)
 
         content.slice!(starting..ending)


### PR DESCRIPTION
This pull request is leading up to a fix for hanami/hanami#921

Add TargetRubyVersion to rubocop config to silence warnings about
mismatch between rubocop config and gemspec.
Switch =~ usage to match? per rubocop in files.remove_block

It appears that jruby 9.2.0.0 is available on travis per: https://travis-ci.org/rubocop-hq/rubocop/jobs/398743238