### PR TITLE
logger: fix default formatter for hashes

### DIFF
--- a/lib/hanami/utils/query_string.rb
+++ b/lib/hanami/utils/query_string.rb
@@ -24,7 +24,7 @@ module Hanami
       def self.call(input)
         case input
         when ::Hash
-          input.map { |key, value| "#{key}=#{value}" }.join(HASH_SEPARATOR)
+          input.map { |key, value| "#{key}=#{value.inspect}" }.join(HASH_SEPARATOR)
         else
           input.to_s
         end

--- a/lib/hanami/utils/query_string.rb
+++ b/lib/hanami/utils/query_string.rb
@@ -8,6 +8,10 @@ module Hanami
     #
     # @since 1.2.0
     module QueryString
+      # @since x.x.x
+      # @api private
+      HASH_SEPARATOR = ","
+
       # Serialize input into a query string
       #
       # @param input [Object] the input
@@ -20,7 +24,7 @@ module Hanami
       def self.call(input)
         case input
         when ::Hash
-          input.to_a.join("=")
+          input.map { |key, value| "#{key}=#{value}" }.join(HASH_SEPARATOR)
         else
           input.to_s
         end

--- a/spec/unit/hanami/logger_spec.rb
+++ b/spec/unit/hanami/logger_spec.rb
@@ -470,7 +470,7 @@ RSpec.describe Hanami::Logger do
             class TestLogger < Hanami::Logger; end
             TestLogger.new.info(foo: "bar")
           end
-        expect(output).to eq "[hanami] [INFO] [2017-01-15 16:00:23 +0100] foo=bar\n"
+        expect(output).to eq %([hanami] [INFO] [2017-01-15 16:00:23 +0100] foo="bar"\n)
       end
 
       it 'has key=value format for error messages' do
@@ -548,7 +548,7 @@ RSpec.describe Hanami::Logger do
             class TestLogger < Hanami::Logger; end
             TestLogger.new.info(foo: :bar)
           end
-        expect(output).to eq "[hanami] [INFO] [2017-01-15 16:00:23 +0100] foo=bar\n"
+        expect(output).to eq "[hanami] [INFO] [2017-01-15 16:00:23 +0100] foo=:bar\n"
       end
 
       it 'has key=value format for not string messages' do

--- a/spec/unit/hanami/utils/query_string_spec.rb
+++ b/spec/unit/hanami/utils/query_string_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hanami::Utils::QueryString do
   describe ".call" do
     context "when ::Hash" do
       it "serializes input" do
-        expect(described_class.call(foo: "bar")).to eq("foo=bar")
+        expect(described_class.call(foo: "1", bar: nil, baz: "hello")).to eq("foo=1,bar=,baz=hello")
       end
     end
 

--- a/spec/unit/hanami/utils/query_string_spec.rb
+++ b/spec/unit/hanami/utils/query_string_spec.rb
@@ -1,16 +1,37 @@
 require "hanami/utils/query_string"
+require "bigdecimal"
 
 RSpec.describe Hanami::Utils::QueryString do
   describe ".call" do
     context "when ::Hash" do
       it "serializes input" do
-        expect(described_class.call(foo: "1", bar: nil, baz: "hello")).to eq("foo=1,bar=,baz=hello")
+        expect(described_class.call(foo: 1, bar: nil, greet: "hello, world")).to eq(%(foo=1,bar=nil,greet="hello, world"))
       end
     end
 
     context "when nil" do
       it "serializes input" do
         expect(described_class.call(nil)).to eq("")
+      end
+    end
+
+    context "Ruby types" do
+      it "serializes nil" do
+        expect(described_class.call(foo: nil)).to eq("foo=nil")
+      end
+
+      it "serializes string" do
+        expect(described_class.call(foo: "bar")).to eq(%(foo="bar"))
+      end
+
+      it "serializes number" do
+        expect(described_class.call(foo: 1)).to eq("foo=1")
+        expect(described_class.call(foo: 3.14)).to eq("foo=3.14")
+      end
+
+      it "serializes string representation of a number" do
+        expect(described_class.call(foo: "1")).to eq(%(foo="1"))
+        expect(described_class.call(foo: "3.14")).to eq(%(foo="3.14"))
       end
     end
   end


### PR DESCRIPTION
Fixes #295

```
q = {foo: "1", bar: nil, baz: "hello"}
Hanami::Logger.new.debug(q)
[Hanami] [DEBUG] [2018-09-17 10:07:24 +0200] foo=25,bar=,baz=What is this?
```

I suggest to use json formatter instead of default formatter  because it supports deep nested hashes. 