### PR TITLE
Fix #299 by adding require to lib/hanami/utils.rb

### DIFF
--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -1,5 +1,8 @@
 # Hanami - The web, with simplicity
 #
+
+require 'pathname'
+
 # @since 0.1.0
 module Hanami
   require 'hanami/utils/version'


### PR DESCRIPTION
Simple as that. This was passing `bundle exec rake` but `bundle exec rspec spec/unit/hanami/utils/string_spec.rb` would die with a `NameError`, as described in #299.

Fixes #299