### PR TITLE
Add Hanami::Utils::String.squish and #squish methods

### DIFF
--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -1,5 +1,8 @@
 # Hanami - The web, with simplicity
 #
+
+require 'pathname'
+
 # @since 0.1.0
 module Hanami
   require 'hanami/utils/version'

--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -382,6 +382,25 @@ module Hanami
         end
       end
 
+      # Return `input`, first removing all white-space on both ends of the
+      # string, and then changing remaining consecutive white-space groups into
+      # one space each.
+      #
+      # @param input [::String] the input
+      #
+      # @return [::String] the squished string
+      # @since FIXME: TBD
+      #
+      # @example
+      #   require 'hanami/utils/string'
+      #
+      #   str = "  This\nwas    input with  excess\t\t\twhitespace.      "
+      #   Hanami::Utils::String.squish(str)
+      #     # => 'This was input with excess whitespace.'
+      def self.squish(input)
+        input.gsub(/[[:space:]]+/, " ").strip
+      end
+
       # Initialize the string
       #
       # @param string [::String, Symbol] the value we want to initialize
@@ -701,6 +720,27 @@ module Hanami
         else
           self
         end
+      end
+
+      # Return `input`, first removing all white-space on both ends of the
+      # string, and then changing remaining consecutive white-space groups into
+      # one space each.
+      #
+      # @param input [::String] the input
+      #
+      # @return [::String] the squished string
+      # @since FIXME: TBD
+      #
+      # @example
+      #   require 'hanami/utils/string'
+      #
+      #   str = "  This\nwas    input with  excess\t\t\twhitespace.      "
+      #   input = Hanami::Utils::String.new str
+      #   # ...
+      #   input.squish
+      #     # => 'This was input with excess whitespace.'
+      def squish
+        self.class.squish(self)
       end
 
       # Override Ruby's method_missing in order to provide ::String interface

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -406,6 +406,42 @@ RSpec.describe Hanami::Utils::String do
     end
   end
 
+  describe '.squish' do
+    it 'returns an instance of ::String' do
+      expect(Hanami::Utils::String.squish('hanami')).to be_kind_of(::String)
+    end
+
+    it "doesn't mutate input" do
+      input = 'hanami'
+      Hanami::Utils::String.squish(input)
+
+      expect(input).to eq('hanami')
+    end
+
+    it 'removes any leading white-space' do
+      input = '                         Over here!'
+      expect(Hanami::Utils::String.squish(input)).to eq('Over here!')
+    end
+
+    it 'removes any trailing white-space' do
+      input = "Hanami\n\n"
+      expect(Hanami::Utils::String.squish(input)).to eq('Hanami')
+    end
+
+    it 'replaces whitespace characters with a single space' do
+      input = "Testing\tthe\rinput\nstring"
+      expected = 'Testing the input string'
+      expect(Hanami::Utils::String.squish(input)).to eq(expected)
+    end
+
+    it 'combines all cleanup in a single call' do
+      input = %(<span class="foo">           bar\n             Foo       the) \
+        "\n\tbaz</span>"
+      expected = '<span class="foo"> bar Foo the baz</span>'
+      expect(Hanami::Utils::String.squish(input)).to eq(expected)
+    end
+  end
+
   describe '#titleize' do
     it 'returns an instance of Hanami::Utils::String' do
       expect(Hanami::Utils::String.new('hanami').titleize).to be_kind_of(Hanami::Utils::String)
@@ -724,6 +760,38 @@ RSpec.describe Hanami::Utils::String do
     it 'returns the initial string no match' do
       result = Hanami::Utils::String.new('index').rsub(%r{/}, '#')
       expect(result).to eq('index')
+    end
+  end
+
+  describe '#squish' do
+    it "doesn't mutate input" do
+      source_str = "   Marvellous   Madness\n"
+      input = Hanami::Utils::String.new source_str
+      input.squish
+      expect(input).to eq(source_str)
+    end
+
+    it 'removes any leading white-space' do
+      input = Hanami::Utils::String.new '                         Over here!'
+      expect(input.squish.to_s).to eq('Over here!')
+    end
+
+    it 'removes any trailing white-space' do
+      input = "Hanami\n\n"
+      expect(Hanami::Utils::String.squish(input)).to eq('Hanami')
+    end
+
+    it 'replaces whitespace characters with a single space' do
+      input = "Testing\tthe\rinput\nstring"
+      expected = 'Testing the input string'
+      expect(Hanami::Utils::String.squish(input)).to eq(expected)
+    end
+
+    it 'combines all cleanup in a single call' do
+      input = %(<span class="foo">           bar\n             Foo       the) \
+        "\n\tbaz</span>"
+      expected = '<span class="foo"> bar Foo the baz</span>'
+      expect(Hanami::Utils::String.squish(input)).to eq(expected)
     end
   end
 


### PR DESCRIPTION
As proposed in Issue #298. 

The patch previously submitted as #300 is incorporated; without that, `rspec` cannot run individual spec files. (Without #300, `bundle exec rspec spec/unit/hanami/utils/string_spec.rb` will fail but `bundle exec rake` will pass due to a missing `require`.)