### PR TITLE
Agnostic ArgumentError's message check in utils/string_spec.rb

### DIFF
--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe Hanami::Utils::String do
     it "raises error when given proc has arity not equal to 1" do
       input = "Cherry"
 
-      expect {
+      expect do
         Hanami::Utils::String.transform(input, -> { "blossom" })
-      }.to raise_error(ArgumentError, /wrong number of arguments (.*1.*0)/)
+      end.to raise_error(ArgumentError, /wrong number of arguments (.*1.*0)/)
     end
   end
 

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -56,13 +56,9 @@ RSpec.describe Hanami::Utils::String do
     it "raises error when given proc has arity not equal to 1" do
       input = "Cherry"
 
-      message = if Hanami::Utils.jruby?
-                  "wrong number of arguments (1 for 0)"
-                else
-                  "wrong number of arguments (given 1, expected 0)"
-                end
-
-      expect { Hanami::Utils::String.transform(input, -> { "blossom" }) }.to raise_error(ArgumentError, message)
+      expect {
+        Hanami::Utils::String.transform(input, -> { "blossom" })
+      }.to raise_error(ArgumentError, /wrong number of arguments (.*1.*0)/)
     end
   end
 


### PR DESCRIPTION
The motivation behind this is the following issue https://github.com/oracle/truffleruby/issues/1467 in Truffleruby issues. They already fixes on their side.

As mentioned @eregon in his comment https://github.com/oracle/truffleruby/issues/1467#issuecomment-438354081 this improving portability of the library than making checking based on `RUBY_ENGINE`