### PR TITLE
Add instance_of?, is_a?, kind_of? To BasicObject

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,9 @@
+kind: pipeline
+name: default
+
+steps:
+- name: test
+  image: ruby
+  commands:
+  - bundle install --jobs=3 --retry=3
+  - bundle exec rake

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,9 +1,301 @@
 kind: pipeline
-name: default
+name: ruby-2-6
+group: build
 
 steps:
-- name: test
-  image: ruby
+- name: install
+  image: ruby:2.6
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
   commands:
+  - ruby -v
+  - gem install bundler
   - bundle install --jobs=3 --retry=3
-  - bundle exec rake
+
+- name: unit
+  image: ruby:2.6
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: isolation
+  image: ruby:2.6
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ./script/test isolation
+
+- name: quality
+  image: ruby:2.6
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: ruby-2-5
+group: build
+
+steps:
+- name: install
+  image: ruby:2.5
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.5
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: isolation
+  image: ruby:2.5
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ./script/test isolation
+
+- name: quality
+  image: ruby:2.5
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: ruby-2-4
+group: build
+
+steps:
+- name: install
+  image: ruby:2.4
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.4
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: isolation
+  image: ruby:2.4
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ./script/test isolation
+
+- name: quality
+  image: ruby:2.4
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: ruby-2-3
+group: build
+
+steps:
+- name: install
+  image: ruby:2.3
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.3
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: isolation
+  image: ruby:2.3
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ./script/test isolation
+
+- name: quality
+  image: ruby:2.3
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: jruby-9-2
+group: build
+
+steps:
+- name: install
+  image: jruby:9.2
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: jruby:9.2
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: quality
+  image: jruby:9.2
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: jruby-9-1
+group: build
+
+steps:
+- name: install
+  image: jruby:9.1
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: jruby:9.1
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: isolation
+  image: jruby:9.1
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ./script/test isolation
+
+- name: quality
+  image: jruby:9.1
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: slack
+group: build
+
+clone:
+  disable: true
+
+depends_on:
+  - jruby-9-1
+
+steps:
+- name: slack
+  image: plugins/slack
+  settings:
+    link_names: true
+    webhook:
+      from_secret: slack
+      channel: dev
+  when:
+    event:
+    - push

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 
 gem 'gson', '>= 0.6', require: false, platforms: :jruby
 
-gem 'rubocop', '~> 0.68.1', require: false
+gem 'rubocop', '~> 0.71.0', require: false
 gem 'codecov', require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 
 gem 'gson', '>= 0.6', require: false, platforms: :jruby
 
-gem 'rubocop', '~> 0.65.0', require: false
+gem 'rubocop', '~> 0.68.1', require: false
 gem 'codecov', require: false, group: :test

--- a/lib/hanami/utils/basic_object.rb
+++ b/lib/hanami/utils/basic_object.rb
@@ -29,34 +29,43 @@ module Hanami
       # rubocop:enable Style/FormatStringToken
       # rubocop:enable Style/FormatString
 
-      # @!method instance_of?(class1)
+      # Determine if self is an instance of given class or module
       #
-      #   Returns true if obj is an instance of the given class.
-      #   @return [TrueClass,FalseClass]
+      # @param [Class,Module] the class of module to verify
       #
-      #   @see http://ruby-doc.org/core/Object.html#method-i-instance_of-3F
+      # @return [TrueClass,FalseClass] the result of the check
+      #
+      # @raise [TypeError] if the given argument is not of the expected types
+      #
+      # @since 1.3.2
+      #
+      # @see http://ruby-doc.org/core/Object.html#method-i-instance_of-3F
       define_method :instance_of?, ::Object.instance_method(:instance_of?)
 
-      # @!method is_a?(class1)
+      # Determine if self is of the type of the object class or module
       #
-      #   Returns true if class is the class of
-      #   obj, or if class is one of the superclasses of
-      #   obj or modules included in obj.
+      # @param [Class,Module] the class of module to verify
       #
-      #   @return [TrueClass,FalseClass]
+      # @return [TrueClass,FalseClass] the result of the check
       #
-      #   @see http://ruby-doc.org/core/Object.html#method-i-is_a-3F
+      # @raise [TypeError] if the given argument is not of the expected types
+      #
+      # @since 1.3.2
+      #
+      # @see http://ruby-doc.org/core/Object.html#method-i-is_a-3F
       define_method :is_a?, ::Object.instance_method(:is_a?)
 
-      # @!method kind_of?(class1)
+      # Determine if self is of the kind of the object class or module
       #
-      #   Returns true if class is the class of
-      #   obj, or if class is one of the superclasses of
-      #   obj or modules included in obj.
+      # @param [Class,Module] the class of module to verify
       #
-      #   @return [TrueClass,FalseClass]
+      # @return [TrueClass,FalseClass] the result of the check
       #
-      #   @see http://ruby-doc.org/core/Object.html#method-i-kind_of-3F
+      # @raise [TypeError] if the given argument is not of the expected types
+      #
+      # @since 1.3.2
+      #
+      # @see http://ruby-doc.org/core/Object.html#method-i-kind_of-3F
       define_method :kind_of?, ::Object.instance_method(:kind_of?)
 
       # Alias for __id__

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -1043,7 +1043,7 @@ module Hanami
       # @api private
       def self.inspect_type_error(arg)
         (arg.respond_to?(:inspect) ? arg.inspect : arg.to_s) << ' '
-      rescue NoMethodError => _
+      rescue NoMethodError
         # missing the #respond_to? method, fall back to returning the class' name
         begin
           arg.class.name << ' instance '

--- a/script/test
+++ b/script/test
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+run_tests() {
+  local type=$1
+  local pwd=$PWD
+  local root="$pwd/spec/$type"
+
+  for test in $(find $root -name '*_spec.rb')
+  do
+    run_test $root $test
+
+    if [ $? -ne 0 ]; then
+      local exit_code=$?
+      echo "Failing test: $test"
+      exit $exit_code
+    fi
+  done
+}
+
+run_test() {
+  local root=$1
+  local test=$2
+
+  printf "\n\n\nRunning: $test\n"
+  COVERAGE=true ruby $test --options $root/.rspec
+}
+
+main() {
+  local type=$1
+  run_tests $type
+}
+
+main $1

--- a/spec/unit/hanami/logger_spec.rb
+++ b/spec/unit/hanami/logger_spec.rb
@@ -516,6 +516,8 @@ RSpec.describe Hanami::Logger do
 
         it 'colorizes when for tty by default (i.e. when colorizer: nil)' do
           stdout = IO.new($stdout.fileno)
+          skip unless stdout.tty?
+
           expect(stdout).to receive(:write).with(
             "[\e[34mhanami\e[0m] [\e[35mINFO\e[0m] [\e[36m2017-01-15 16:00:23 +0100\e[0m] foo\n"
           )
@@ -525,6 +527,8 @@ RSpec.describe Hanami::Logger do
 
         it 'colorizes for tty when colorizer: nil' do
           stdout = IO.new($stdout.fileno)
+          skip unless stdout.tty?
+
           expect(stdout).to receive(:write).with(
             "[\e[34mhanami\e[0m] [\e[35mINFO\e[0m] [\e[36m2017-01-15 16:00:23 +0100\e[0m] foo\n"
           )

--- a/spec/unit/hanami/utils/basic_object_spec.rb
+++ b/spec/unit/hanami/utils/basic_object_spec.rb
@@ -52,79 +52,113 @@ RSpec.describe Hanami::Utils::BasicObject do
   end
 
   describe '#instance_of?' do
-    subject { object.instance_of?(TestClass) }
+    subject { TestClass.new }
 
     context 'when object is instance of the given class' do
-      let(:object) { TestClass.new }
-
-      it { is_expected.to eq(true) }
+      it 'returns true' do
+        expect(subject.instance_of?(TestClass)).to be(true)
+      end
     end
 
     context 'when object is not instance of the given class' do
-      let(:object) { 'not_test_class' }
+      it 'returns false' do
+        expect(subject.instance_of?(::String)).to be(false)
+      end
+    end
 
-      it { is_expected.to eq(false) }
+    context 'when given argument is not a class or module' do
+      it 'raises error' do
+        expect { subject.instance_of?("foo") }.to raise_error(TypeError)
+      end
     end
   end
 
   describe '#is_a?' do
+    subject { TestClass.new }
     let(:test_class) { TestClass }
-    subject { object.is_a?(test_class) }
 
     context 'when object is instance of the given class' do
-      let(:object) { test_class.new }
+      it 'returns true' do
+        expect(subject.is_a?(TestClass)).to be(true)
+      end
+    end
 
-      it { is_expected.to eq(true) }
+    context 'when object is not instance of the given class' do
+      it 'returns false' do
+        expect(subject.is_a?(::String)).to be(false)
+      end
+    end
+
+    context 'when given argument is not a class or module' do
+      it 'raises error' do
+        expect { subject.is_a?("foo") }.to raise_error(TypeError)
+      end
     end
 
     context 'when object is instance of the subclass' do
-      let(:object) { Class.new(test_class).new }
+      subject { Class.new(TestClass).new }
 
-      it { is_expected.to eq(true) }
+      it 'returns true' do
+        expect(subject.is_a?(TestClass)).to be(true)
+      end
     end
 
     context 'when object has given module included' do
-      let(:test_class) { Module.new }
-      let(:object) do
-        mdl = test_class
-        Class.new do
-          include mdl
-        end.new
+      subject do
+        m = mod
+        Class.new { include m }.new
       end
 
-      it { is_expected.to eq(true) }
+      let(:mod) { Module.new }
+
+      it 'returns true' do
+        expect(subject.is_a?(mod)).to be(true)
+      end
     end
   end
 
+  # rubocop:disable Style/ClassCheck
   describe '#kind_of?' do
-    let(:test_class) { TestClass }
-
-    # rubocop:disable Style/ClassCheck
-    subject { object.kind_of?(test_class) }
-
-    # rubocop:enable Style/ClassCheck
     context 'when object is instance of the given class' do
-      let(:object) { test_class.new }
+      subject { TestClass.new }
 
-      it { is_expected.to eq(true) }
+      it 'returns true' do
+        expect(subject.kind_of?(TestClass)).to be(true)
+      end
     end
 
     context 'when object is instance of the subclass' do
-      let(:object) { Class.new(test_class).new }
+      subject { Class.new(TestClass).new }
 
-      it { is_expected.to eq(true) }
+      it 'returns true' do
+        expect(subject.kind_of?(TestClass)).to be(true)
+      end
+    end
+
+    context 'when object is not instance of the given class' do
+      it 'returns false' do
+        expect(subject.kind_of?(::String)).to be(false)
+      end
+    end
+
+    context 'when given argument is not a class or module' do
+      it 'raises error' do
+        expect { subject.kind_of?("foo") }.to raise_error(TypeError)
+      end
     end
 
     context 'when object has given module included' do
-      let(:test_class) { Module.new }
-      let(:object) do
-        mdl = test_class
-        Class.new do
-          include mdl
-        end.new
+      subject do
+        m = mod
+        Class.new { include m }.new
       end
 
-      it { is_expected.to eq(true) }
+      let(:mod) { Module.new }
+
+      it 'returns true' do
+        expect(subject.kind_of?(mod)).to be(true)
+      end
     end
   end
+  # rubocop:enable Style/ClassCheck
 end

--- a/spec/unit/hanami/utils/deprecation_spec.rb
+++ b/spec/unit/hanami/utils/deprecation_spec.rb
@@ -22,14 +22,8 @@ end
 
 RSpec.describe Hanami::Utils::Deprecation do
   it 'prints a deprecation warning for direct call' do
-    stack = if Hanami::Utils.jruby?
-              "#{__FILE__}:31:in `block in (root)'"
-            else
-              "#{__FILE__}:31:in `block (3 levels) in <top (required)>'"
-            end
-
     expect { DeprecationTest.new.old_method }
-      .to output(include("old_method is deprecated, please use new_method - called from: #{stack}.")).to_stderr
+      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:25")).to_stderr
   end
 
   it 'prints a deprecation warning for nested call' do

--- a/spec/unit/hanami/utils/escape_spec.rb
+++ b/spec/unit/hanami/utils/escape_spec.rb
@@ -363,7 +363,12 @@ RSpec.describe Hanami::Utils::Escape do
             end
 
             it 'escapes a Time' do
-              time_string = Hanami::Utils.jruby? ? '2016-01-27 12:00:00 UTC' : '2016-01-27 12:00:00 +0000'
+              time_string = if Hanami::Utils.jruby? && JRUBY_VERSION.match(/\A9\.1/)
+                              '2016-01-27 12:00:00 UTC'
+                            else
+                              '2016-01-27 12:00:00 +0000'
+                            end
+
               result = mod.html(Time.new(2016, 0o1, 27, 12, 0, 0, 0))
               expect(result).to eq time_string
             end


### PR DESCRIPTION
The lack of Hanami::Interactor::Result#is_a? causes my test suite to error in such examples:

```ruby
it { is_expected.to satisfy(&:failure?) }
```
