### PR TITLE
Allow `Hanami::Utils::FileList` to accept multiple tokens

### DIFF
--- a/lib/hanami/utils/file_list.rb
+++ b/lib/hanami/utils/file_list.rb
@@ -14,8 +14,42 @@ module Hanami
       # @since 0.9.0
       #
       # @see https://ruby-doc.org/core/Dir.html#method-c-glob
+      #
+      # @example simple usage
+      #   require "hanami/utils/file_list"
+      #
+      #   Hanami::Utils::FileList["spec/support/fixtures/file_list/*.rb"]
+      #   # => [
+      #     "spec/support/fixtures/file_list/a.rb",
+      #     "spec/support/fixtures/file_list/aa.rb",
+      #     "spec/support/fixtures/file_list/ab.rb"
+      #   ]
+      #
+      # @example multiple directories
+      #   require "hanami/utils/file_list"
+      #
+      #   Hanami::Utils::FileList["spec/support/fixtures/file_list/*.rb", "spec/support/fixtures/file_list/nested/*.rb"]
+      #   # => [
+      #     "spec/support/fixtures/file_list/a.rb",
+      #     "spec/support/fixtures/file_list/aa.rb",
+      #     "spec/support/fixtures/file_list/ab.rb",
+      #     "spec/support/fixtures/file_list/nested/c.rb"
+      #   ]
+      #
+      # @example token usage
+      #   require "hanami/utils/file_list"
+      #
+      #   Hanami::Utils::FileList["spec", "support", "fixtures", "file_list", "*.rb"]
+      #   # => [
+      #     "spec/support/fixtures/file_list/a.rb",
+      #     "spec/support/fixtures/file_list/aa.rb",
+      #     "spec/support/fixtures/file_list/ab.rb"
+      #   ]
       def self.[](*args)
-        Dir.glob(*args).sort!
+        directories = *args
+        directories = ::File.join(*args) unless args.any? { |a| a.include?(::File::SEPARATOR) }
+
+        Dir.glob(directories).sort!
       end
     end
   end

--- a/lib/hanami/utils/file_list.rb
+++ b/lib/hanami/utils/file_list.rb
@@ -25,17 +25,6 @@ module Hanami
       #     "spec/support/fixtures/file_list/ab.rb"
       #   ]
       #
-      # @example multiple directories
-      #   require "hanami/utils/file_list"
-      #
-      #   Hanami::Utils::FileList["spec/support/fixtures/file_list/*.rb", "spec/support/fixtures/file_list/nested/*.rb"]
-      #   # => [
-      #     "spec/support/fixtures/file_list/a.rb",
-      #     "spec/support/fixtures/file_list/aa.rb",
-      #     "spec/support/fixtures/file_list/ab.rb",
-      #     "spec/support/fixtures/file_list/nested/c.rb"
-      #   ]
-      #
       # @example token usage
       #   require "hanami/utils/file_list"
       #
@@ -46,10 +35,7 @@ module Hanami
       #     "spec/support/fixtures/file_list/ab.rb"
       #   ]
       def self.[](*args)
-        directories = *args
-        directories = ::File.join(*args) unless args.any? { |a| a.to_s.include?(::File::SEPARATOR) }
-
-        Dir.glob(directories).sort!
+        Dir.glob(::File.join(*args)).sort!
       end
     end
   end

--- a/lib/hanami/utils/file_list.rb
+++ b/lib/hanami/utils/file_list.rb
@@ -47,7 +47,7 @@ module Hanami
       #   ]
       def self.[](*args)
         directories = *args
-        directories = ::File.join(*args) unless args.any? { |a| a.include?(::File::SEPARATOR) }
+        directories = ::File.join(*args) unless args.any? { |a| a.to_s.include?(::File::SEPARATOR) }
 
         Dir.glob(directories).sort!
       end

--- a/spec/unit/hanami/utils/file_list_spec.rb
+++ b/spec/unit/hanami/utils/file_list_spec.rb
@@ -12,5 +12,24 @@ RSpec.describe Hanami::Utils::FileList do
         "spec/support/fixtures/file_list/ab.rb"
       ]
     end
+
+    it "accepts multiple directory names" do
+      list = Hanami::Utils::FileList["spec/support/fixtures/file_list/*.rb", "spec/support/fixtures/file_list/nested/*.rb"]
+      expect(list).to eq [
+        "spec/support/fixtures/file_list/a.rb",
+        "spec/support/fixtures/file_list/aa.rb",
+        "spec/support/fixtures/file_list/ab.rb",
+        "spec/support/fixtures/file_list/nested/c.rb"
+      ]
+    end
+
+    it "finds files constructing path from directory names" do
+      list = Hanami::Utils::FileList["spec", "support", "fixtures", "file_list", "*.rb"]
+      expect(list).to eq [
+        "spec/support/fixtures/file_list/a.rb",
+        "spec/support/fixtures/file_list/aa.rb",
+        "spec/support/fixtures/file_list/ab.rb"
+      ]
+    end
   end
 end

--- a/spec/unit/hanami/utils/file_list_spec.rb
+++ b/spec/unit/hanami/utils/file_list_spec.rb
@@ -14,16 +14,6 @@ RSpec.describe Hanami::Utils::FileList do
       ]
     end
 
-    it "accepts multiple directory names" do
-      list = Hanami::Utils::FileList["spec/support/fixtures/file_list/*.rb", "spec/support/fixtures/file_list/nested/*.rb"]
-      expect(list).to eq [
-        "spec/support/fixtures/file_list/a.rb",
-        "spec/support/fixtures/file_list/aa.rb",
-        "spec/support/fixtures/file_list/ab.rb",
-        "spec/support/fixtures/file_list/nested/c.rb"
-      ]
-    end
-
     it "finds files constructing path from directory names" do
       list = Hanami::Utils::FileList["spec", "support", "fixtures", "file_list", "*.rb"]
       expect(list).to eq [
@@ -39,6 +29,16 @@ RSpec.describe Hanami::Utils::FileList do
         "spec/support/fixtures/file_list/a.rb",
         "spec/support/fixtures/file_list/aa.rb",
         "spec/support/fixtures/file_list/ab.rb"
+      ]
+    end
+
+    it "accepts root directory and path tokens" do
+      root = Pathname(Dir.pwd).realpath
+      list = Hanami::Utils::FileList[root, "spec", "support", "fixtures", "file_list", "*.rb"]
+      expect(list).to eq [
+        root.join("spec/support/fixtures/file_list/a.rb").to_s,
+        root.join("spec/support/fixtures/file_list/aa.rb").to_s,
+        root.join("spec/support/fixtures/file_list/ab.rb").to_s
       ]
     end
   end

--- a/spec/unit/hanami/utils/file_list_spec.rb
+++ b/spec/unit/hanami/utils/file_list_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "hanami/utils/file_list"
+require "pathname"
 
 RSpec.describe Hanami::Utils::FileList do
   describe ".[]" do
@@ -25,6 +26,15 @@ RSpec.describe Hanami::Utils::FileList do
 
     it "finds files constructing path from directory names" do
       list = Hanami::Utils::FileList["spec", "support", "fixtures", "file_list", "*.rb"]
+      expect(list).to eq [
+        "spec/support/fixtures/file_list/a.rb",
+        "spec/support/fixtures/file_list/aa.rb",
+        "spec/support/fixtures/file_list/ab.rb"
+      ]
+    end
+
+    it "accepts Pathname as argument" do
+      list = Hanami::Utils::FileList[Pathname("spec/support/fixtures/file_list/*.rb")]
       expect(list).to eq [
         "spec/support/fixtures/file_list/a.rb",
         "spec/support/fixtures/file_list/aa.rb",


### PR DESCRIPTION
## Existing

```ruby
# frozen_string_literal: true

require "hanami/utils/file_list"

Hanami::Utils::FileList["spec/support/fixtures/file_list/*.rb"]
# => [
  "spec/support/fixtures/file_list/a.rb",
  "spec/support/fixtures/file_list/aa.rb",
  "spec/support/fixtures/file_list/ab.rb"
]
```

## Enhancement

```ruby
# frozen_string_literal: true

require "hanami/utils/file_list"

Hanami::Utils::FileList["spec", "support", "fixtures", "file_list", "*.rb"]
# => [
  "spec/support/fixtures/file_list/a.rb",
  "spec/support/fixtures/file_list/aa.rb",
  "spec/support/fixtures/file_list/ab.rb"
]
```

## Why

From the work I'm doing on `hanami`, I want to support this usage:

```ruby
Hanami::Utils::FileList[c.root, "apps", app.to_s, "actions", "**", "*.rb"].each do |path|
  # ...
end
```
