### PR TITLE
Utils::String#underscore handles dots

### DIFF
--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -253,7 +253,7 @@ module Hanami
         string.gsub!(NAMESPACE_SEPARATOR, UNDERSCORE_SEPARATOR)
         string.gsub!(/([A-Z\d]+)([A-Z][a-z])/, UNDERSCORE_DIVISION_TARGET)
         string.gsub!(/([a-z\d])([A-Z])/, UNDERSCORE_DIVISION_TARGET)
-        string.gsub!(/[[:space:]]|\-/, UNDERSCORE_DIVISION_TARGET)
+        string.gsub!(/[[:space:]]|\-|\./, UNDERSCORE_DIVISION_TARGET)
         string.downcase
       end
 

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -201,6 +201,11 @@ RSpec.describe Hanami::Utils::String do
       expect(string).to eq('hanami_utils')
     end
 
+    it 'handles dots' do
+      string = Hanami::Utils::String.underscore('hanami.utils')
+      expect(string).to eq('hanami_utils')
+    end
+
     it 'handles accented letters' do
       string = Hanami::Utils::String.underscore('è vero')
       expect(string).to eq('è_vero')


### PR DESCRIPTION
I first stuck to this problem when decided to generate new hanami project.
```
hanami new project.name
```
this command will create `module Project.name`, which is definitely incorrect and fails. Though, it's quite common to generate projects with the first level domain like `hanamirb.org`.

I've decided that this logic best suit exactly inside `underscore` and doesn't require a separate method for that. Especially in case, it already has whitespace- and dash- filtering.
