### PR TITLE
Run specs in TruffleRuby in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ rvm:
   - jruby-9.1.9.0
   - ruby-head
   - jruby-head
+  - truffleruby
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: jruby-9.1.9.0
+    - rvm: truffleruby
 
 notifications:
   webhooks:


### PR DESCRIPTION
Since TruffleRuby 19.2.0 all Hanami::Utils' specs pass 🚀 