### PR TITLE
Ensure `Utils::BasicObject` to lookup constants at the top-level namespace

### DIFF
--- a/lib/hanami/utils/basic_object.rb
+++ b/lib/hanami/utils/basic_object.rb
@@ -4,6 +4,23 @@ module Hanami
     #
     # @since 0.3.5
     class BasicObject < ::BasicObject
+      # Lookup constants at the top-level namespace, if they are missing in the
+      # current context.
+      #
+      # @param name [Symbol] the constant name
+      #
+      # @return [Object, Module] the constant
+      #
+      # @raises [NameError] if the constant cannot be found
+      #
+      # @since x.x.x
+      # @api private
+      #
+      # @see https://ruby-doc.org/core/Module.html#method-i-const_missing
+      def self.const_missing(name)
+        ::Object.const_get(name)
+      end
+
       # Return the class for debugging purposes.
       #
       # @since 0.3.5

--- a/spec/unit/hanami/utils/basic_object_spec.rb
+++ b/spec/unit/hanami/utils/basic_object_spec.rb
@@ -1,10 +1,32 @@
 require 'hanami/utils/basic_object'
 require 'pp'
 
+class ExternalTestClass
+end
+
 class TestClass < Hanami::Utils::BasicObject
+  class InternalTestClass
+  end
+
+  def internal
+    InternalTestClass
+  end
+
+  def external
+    ExternalTestClass
+  end
 end
 
 RSpec.describe Hanami::Utils::BasicObject do
+  describe '.const_missing' do
+    subject { TestClass.new }
+
+    it 'lookups constants at the top-level namespace' do
+      expect(subject.internal).to eq(TestClass::InternalTestClass)
+      expect(subject.external).to eq(ExternalTestClass)
+    end
+  end
+
   describe '#respond_to_missing?' do
     it 'raises an exception if respond_to? method is not implemented' do
       expect { TestClass.new.respond_to?(:no_existing_method) }


### PR DESCRIPTION
Ensure `Utils::BasicObject` to lookup constants at the top-level namespace, if they are missing in the current context.

Thanks to @jeremyevans for the suggestion: https://github.com/rtomayko/tilt/issues/347#issuecomment-534755061