### PR TITLE
Revert "Run specs in TruffleRuby in Travis CI"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,12 @@ rvm:
   - jruby-9.1.9.0
   - ruby-head
   - jruby-head
-  - truffleruby
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: jruby-9.1.9.0
-    - rvm: truffleruby
 
 notifications:
   webhooks:


### PR DESCRIPTION
Reverts hanami/utils#341

TruffleRuby build keeps 16 minutes to complete and it's constantly failing. See an example: https://travis-ci.org/hanami/utils/jobs/589308192

This isn't a definitive NO to TruffleRuby. But for now it's just a waste of time and resources to keep it as it is in CI build.

/cc @davydovanton @deepj 