### PR TITLE
Store raised exception in rack.errors and rack.exception

### DIFF
--- a/lib/hanami/utils/rack_error.rb
+++ b/lib/hanami/utils/rack_error.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Utils
+    # This module provides method for saving exceptions
+    # to rack-env:
+    # <tt>rack.errors</tt> - for common Rack SPEC
+    # <tt>rack.exceptions</tt> - for services which track exceptions
+    #
+    # @see http://www.rubydoc.info/github/rack/rack/file/SPEC#The_Error_Stream
+    # @see https://github.com/hanami/controller/issues/133
+    module RackError
+      RACK_ERRORS = 'rack.errors'
+
+      RACK_EXCEPTION = 'rack.exception'
+
+      # Store exception in rack env
+      #
+      # @param env rack-env
+      # @param exception [Exception]
+      def self.save_error_in_rack_env(env, exception)
+        env[RACK_EXCEPTION] = exception
+
+        return unless errors = env[RACK_ERRORS] # rubocop:disable Lint/AssignmentInCondition
+
+        errors.write(_dump_exception(exception))
+        errors.flush
+      end
+
+      # Format exception info with name and backtrace
+      #
+      # @param exception [Exception]
+      def self._dump_exception(exception)
+        [[exception.class, exception.message].compact.join(": "), *exception.backtrace].join("\n\t")
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/utils/rack_error_spec.rb
+++ b/spec/unit/hanami/utils/rack_error_spec.rb
@@ -1,0 +1,23 @@
+require "hanami/utils/rack_error"
+
+RSpec.describe Hanami::Utils::RackError do
+  describe '.save_error_in_rack_env' do
+    let(:exception) do
+      exception = StandardError.new("Exception")
+      exception.set_backtrace(['backtrace/path/1', 'backtrace/path/2'])
+      exception
+    end
+
+    let(:env) { { 'rack.errors' => StringIO.new } }
+
+    it 'writes exception info to rack.errors' do
+      described_class.save_error_in_rack_env(env, exception)
+      expect(env['rack.errors'].string).to eq("StandardError: Exception\n\tbacktrace/path/1\n\tbacktrace/path/2")
+    end
+
+    it 'stores exception info in rack.exception' do
+      described_class.save_error_in_rack_env(env, exception)
+      expect(env['rack.exception']).to eq(exception)
+    end
+  end
+end


### PR DESCRIPTION
@jodosha hello agian :)
Based on our discussion in https://github.com/hanami/hanami/pull/1014 I created this PR. This common utility method can be used in action and in view.
After success merging this PR I can create 2 PRs: one for action (https://github.com/hanami/controller/blob/c12e07954d56b5df5da6e5f9dd05f48634ebc38e/lib/hanami/action/throwable.rb#L160) and one for view (https://github.com/hanami/hanami/blob/master/lib/hanami/rendering_policy.rb#L60)