### PR TITLE
`Utils::Files.append` ensure to work without newline

### DIFF
--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -163,6 +163,7 @@ module Hanami
         mkdir_p(path)
 
         content = ::File.readlines(path)
+        content << "\n" unless content.last.end_with?("\n")
         content << "#{contents}\n"
 
         write(path, content)

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -246,6 +246,19 @@ RSpec.describe Hanami::Utils::Files do
       expect(path).to have_content(expected)
     end
 
+    # https://github.com/hanami/utils/issues/348
+    it "adds a line at the top of a file that doesn't end with a newline" do
+      path = root.join("unshift_missing_newline.rb")
+      content = "get '/tires', to: 'sunshine#index'"
+
+      described_class.write(path, content)
+      described_class.unshift(path, "root to: 'home#index'")
+
+      expected = "root to: 'home#index'\nget '/tires', to: 'sunshine#index'"
+
+      expect(path).to have_content(expected)
+    end
+
     it "raises error if path doesn't exist" do
       path = root.join("unshift_no_exist.rb")
 
@@ -279,10 +292,26 @@ RSpec.describe Hanami::Utils::Files do
       expect(path).to have_content(expected)
     end
 
+    # https://github.com/hanami/utils/issues/348
+    it "adds a line at the bottom of a file that doesn't end with a newline" do
+      path = root.join("append_missing_newline.rb")
+      content = "root to: 'home#index'"
+
+      described_class.write(path, content)
+      described_class.append(path, "get '/tires', to: 'sunshine#index'")
+
+      expected = <<~EOF
+        root to: 'home#index'
+        get '/tires', to: 'sunshine#index'
+      EOF
+
+      expect(path).to have_content(expected)
+    end
+
     it "raises error if path doesn't exist" do
       path = root.join("append_no_exist.rb")
 
-      expect { described_class.unshift(path, "\n Foo.register Append") }.to raise_error do |exception|
+      expect { described_class.append(path, "\n Foo.register Append") }.to raise_error do |exception|
         expect(exception).to be_kind_of(Errno::ENOENT)
         expect(exception.message).to match("No such file or directory")
       end


### PR DESCRIPTION
`Utils::Files` ensure to properly append content when a file doesn't terminate with a newline

Closes #348 