### PR TITLE
API docs: unify documentation approach

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,3 @@ gem 'gson', '>= 0.6', require: false, platforms: :jruby
 
 gem 'rubocop', '~> 0.75.0', require: false
 gem 'codecov', require: false, group: :test
-gem 'simplecov', '<= 0.17.0', require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,4 @@ gem 'gson', '>= 0.6', require: false, platforms: :jruby
 
 gem 'rubocop', '~> 0.75.0', require: false
 gem 'codecov', require: false, group: :test
+gem 'simplecov', '<= 0.17.0', require: false, group: :test

--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -40,7 +40,7 @@ module Hanami
         @success = true
       end
 
-      # Check if the current status is successful
+      # Checks if the current status is successful
       #
       # @return [TrueClass,FalseClass] the result of the check
       #
@@ -52,7 +52,7 @@ module Hanami
       # @since 0.3.5
       alias success? successful?
 
-      # Check if the current status is not successful
+      # Checks if the current status is not successful
       #
       # @return [TrueClass,FalseClass] the result of the check
       #
@@ -61,7 +61,7 @@ module Hanami
         !successful?
       end
 
-      # Force the status to be a failure
+      # Forces the status to be a failure
       #
       # @since 0.3.5
       def fail!
@@ -104,7 +104,7 @@ module Hanami
         errors.first
       end
 
-      # Prepare the result before to be returned
+      # Prepares the result before to be returned
       #
       # @param payload [Hash] an updated payload
       #
@@ -377,7 +377,7 @@ module Hanami
 
     private
 
-    # Check if proceed with <tt>#call</tt> invokation.
+    # Checks if proceed with <tt>#call</tt> invocation.
     # By default it returns <tt>true</tt>.
     #
     # Developers can override it.
@@ -389,7 +389,7 @@ module Hanami
       true
     end
 
-    # Fail and interrupt the current flow.
+    # Fails and interrupts the current flow.
     #
     # @since 0.3.5
     #
@@ -428,7 +428,7 @@ module Hanami
       throw :fail
     end
 
-    # Log an error without interrupting the flow.
+    # Logs an error without interrupting the flow.
     #
     # When used, the returned result won't be successful.
     #
@@ -483,7 +483,7 @@ module Hanami
       false
     end
 
-    # Log an error AND interrupting the flow.
+    # Logs an error and interrupts the flow.
     #
     # When used, the returned result won't be successful.
     #
@@ -579,7 +579,7 @@ module Hanami
       end
     end
 
-    # Expose local instance variables into the returning value of <tt>#call</tt>
+    # Exposes local instance variables into the returning value of <tt>#call</tt>
     #
     # @param instance_variable_names [Symbol,Array<Symbol>] one or more instance
     #   variable names
@@ -588,7 +588,7 @@ module Hanami
     #
     # @see Hanami::Interactor::Result
     #
-    # @example Expose instance variable
+    # @example Exposes instance variable
     #
     #   class Signup
     #     include Hanami::Interactor

--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -7,7 +7,7 @@ require "hanami/utils/files"
 module Hanami
   # Hanami logger
   #
-  # Implement with the same interface of Ruby std lib `Logger`.
+  # Implementation with the same interface of Ruby std lib `Logger`.
   # It uses `STDOUT`, `STDERR`, file name or open file as output stream.
   #
   #
@@ -16,7 +16,7 @@ module Hanami
   #
   # This is useful for auto-tagging the output. Eg (`app=Booshelf`).
   #
-  # When used stand alone (eg. `Hanami::Logger.info`), it tags lines with `app=Shared`.
+  # When used standalone (eg. `Hanami::Logger.info`), it tags lines with `app=Shared`.
   #
   #
   # The available severity levels are the same of `Logger`:
@@ -30,7 +30,7 @@ module Hanami
   #
   # Those levels are available both as class and instance methods.
   #
-  # Also Hanami::Logger support different formatters. Now available only two:
+  # Also Hanami::Logger supports different formatters. Now available only two:
   #
   #   * Formatter (default)
   #   * JSONFormatter
@@ -313,7 +313,7 @@ module Hanami
       super _level(value)
     end
 
-    # Close the logging stream if this stream isn't an STDOUT
+    # Closes the logging stream if this stream isn't an STDOUT
     #
     # @since 0.8.0
     def close

--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -21,7 +21,7 @@ module Hanami
 
     # Checks if the current VM is JRuby
     #
-    # @return [TrueClass,FalseClass] return if the VM is JRuby or not
+    # @return [TrueClass,FalseClass] info whether the VM is JRuby or not
     #
     # @since 0.3.1
     # @api private
@@ -31,7 +31,7 @@ module Hanami
 
     # Checks if the current VM is Rubinius
     #
-    # @return [TrueClass,FalseClass] return if the VM is Rubinius or not
+    # @return [TrueClass,FalseClass] info whether the VM is Rubinius or not
     #
     # @since 0.3.1
     # @api private
@@ -39,7 +39,7 @@ module Hanami
       RUBY_ENGINE == HANAMI_RUBINIUS
     end
 
-    # Recursively require Ruby files under the given directory.
+    # Recursively requires Ruby files under the given directory.
     #
     # If the directory is relative, it implies it's the path from current directory.
     # If the directory is absolute, it uses as it is.
@@ -54,7 +54,7 @@ module Hanami
       for_each_file_in(directory) { |file| require_relative(file) }
     end
 
-    # Recursively reload Ruby files under the given directory.
+    # Recursively reloads Ruby files under the given directory.
     #
     # If the directory is relative, it implies it's the path from current directory.
     # If the directory is absolute, it uses as it is.

--- a/lib/hanami/utils/basic_object.rb
+++ b/lib/hanami/utils/basic_object.rb
@@ -4,7 +4,7 @@ module Hanami
     #
     # @since 0.3.5
     class BasicObject < ::BasicObject
-      # Lookup constants at the top-level namespace, if they are missing in the
+      # Lookups constants at the top-level namespace, if they are missing in the
       # current context.
       #
       # @param name [Symbol] the constant name
@@ -21,7 +21,7 @@ module Hanami
         ::Object.const_get(name)
       end
 
-      # Return the class for debugging purposes.
+      # Returns the class for debugging purposes.
       #
       # @since 0.3.5
       #
@@ -48,7 +48,7 @@ module Hanami
 
       # @!macro [attach] instance_of?(class)
       #
-      # Determine if self is an instance of given class or module
+      # Determines if self is an instance of given class or module
       #
       # @param class [Class,Module] the class of module to verify
       #
@@ -63,7 +63,7 @@ module Hanami
 
       # @!macro [attach] is_a?(class)
       #
-      # Determine if self is of the type of the object class or module
+      # Determines if self is of the type of the object class or module
       #
       # @param class [Class,Module] the class of module to verify
       #
@@ -78,7 +78,7 @@ module Hanami
 
       # @!macro [attach] kind_of?(class)
       #
-      # Determine if self is of the kind of the object class or module
+      # Determines if self is of the kind of the object class or module
       #
       # @param class [Class,Module] the class of module to verify
       #

--- a/lib/hanami/utils/blank.rb
+++ b/lib/hanami/utils/blank.rb
@@ -11,7 +11,7 @@ module Hanami
       # @api private
       STRING_MATCHER = /\A[[:space:]]*\z/.freeze
 
-      # Checks object is blank
+      # Checks if object is blank
       #
       # @example Basic Usage
       #   require 'hanami/utils/blank'
@@ -25,7 +25,7 @@ module Hanami
       #
       # @param object the argument
       #
-      # @return [TrueClass,FalseClass]
+      # @return [TrueClass,FalseClass] info, whether object is blank
       #
       # @since 0.8.0
       # @api private
@@ -44,7 +44,7 @@ module Hanami
         end
       end
 
-      # Checks object is filled
+      # Checks if object is filled
       #
       # @example Basic Usage
       #   require 'hanami/utils/blank'
@@ -58,7 +58,7 @@ module Hanami
       #
       # @param object the argument
       #
-      # @return [TrueClass,FalseClass]
+      # @return [TrueClass,FalseClass] whether the objevt is filled
       #
       # @since 1.0.0
       # @api private

--- a/lib/hanami/utils/blank.rb
+++ b/lib/hanami/utils/blank.rb
@@ -58,7 +58,7 @@ module Hanami
       #
       # @param object the argument
       #
-      # @return [TrueClass,FalseClass] whether the objevt is filled
+      # @return [TrueClass,FalseClass] whether the object is filled
       #
       # @since 1.0.0
       # @api private

--- a/lib/hanami/utils/callbacks.rb
+++ b/lib/hanami/utils/callbacks.rb
@@ -10,7 +10,7 @@ module Hanami
       # @since 0.1.0
       # @private
       class Chain
-        # Return a new chain
+        # Returns a new chain
         #
         # @return [Hanami::Utils::Callbacks::Chain]
         #

--- a/lib/hanami/utils/escape.rb
+++ b/lib/hanami/utils/escape.rb
@@ -397,7 +397,7 @@ module Hanami
         end
       end
 
-      # Escape HTML contents
+      # Escapes HTML contents
       #
       # This MUST be used only for tag contents.
       # Please use `html_attribute` for escaping HTML attributes.
@@ -430,7 +430,7 @@ module Hanami
         result
       end
 
-      # Escape HTML attributes
+      # Escapes HTML attributes
       #
       # This can be used both for HTML attributes and contents.
       # Please note that this is more computational expensive.
@@ -463,7 +463,7 @@ module Hanami
         result
       end
 
-      # Escape URL for HTML attributes (href, src, etc..).
+      # Escapes URL for HTML attributes (href, src, etc..).
       #
       # It extracts from the given input the first valid URL that matches the
       # whitelisted schemes (default: http, https and mailto).
@@ -521,7 +521,7 @@ module Hanami
       class << self
         private
 
-        # Encode the given string into UTF-8
+        # Encodes the given string into UTF-8
         #
         # @param input [String] the input
         #

--- a/lib/hanami/utils/file_list.rb
+++ b/lib/hanami/utils/file_list.rb
@@ -4,7 +4,7 @@ module Hanami
     #
     # @since 0.9.0
     module FileList
-      # Return an ordered list of files, consistent across operating systems
+      # Returns an ordered list of files, consistent across operating systems
       #
       # It has the same signature of <tt>Dir.glob</tt>, it just guarantees to
       # order the results before to return them.

--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -121,15 +121,15 @@ module Hanami
         end
       end
 
-      # Shallow duplicates hash values
+      # Deep duplicates hash values
       #
-      # The output of this function is a shallow duplicate of the input.
+      # The output of this function is a deep duplicate of the input.
       # Any further modification on the input, won't be reflected on the output
       # and viceversa.
       #
       # @param input [::Hash] the input
       #
-      # @return [::Hash] the shallow duplicate of input
+      # @return [::Hash] the deep duplicate of input
       #
       # @since 1.0.1
       #

--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -47,7 +47,7 @@ module Hanami
         self[:symbolize_keys].call(input)
       end
 
-      # Deep symbolize the given hash
+      # Performs deep symbolize on the given hash
       #
       # @param input [::Hash] the input
       #
@@ -69,7 +69,7 @@ module Hanami
         self[:deep_symbolize_keys].call(input)
       end
 
-      # Stringify the given hash
+      # Stringifies the given hash
       #
       # @param input [::Hash] the input
       #
@@ -89,7 +89,7 @@ module Hanami
         self[:stringify_keys].call(input)
       end
 
-      # Deeply stringify the given hash
+      # Deeply stringifies the given hash
       #
       # @param input [::Hash] the input
       #
@@ -121,7 +121,7 @@ module Hanami
         end
       end
 
-      # Deep duplicate hash values
+      # Shallow duplicates hash values
       #
       # The output of this function is a shallow duplicate of the input.
       # Any further modification on the input, won't be reflected on the output
@@ -169,7 +169,7 @@ module Hanami
         end
       end
 
-      # Deep serialize given object into a `Hash`
+      # Deep serializes given object into a `Hash`
       #
       # Please note that the returning `Hash` will use symbols as keys.
       #
@@ -239,7 +239,7 @@ module Hanami
         @hash.default_proc = blk if blk
       end
 
-      # Convert in-place all the keys to Symbol instances.
+      # Converts in-place all the keys to Symbol instances.
       #
       # @return [Hash] self
       #
@@ -263,7 +263,7 @@ module Hanami
         self
       end
 
-      # Convert in-place all the keys to Symbol instances, nested hashes are converted too.
+      # Converts in-place all the keys to Symbol instances, nested hashes are converted too.
       #
       # @return [Hash] self
       #
@@ -289,7 +289,7 @@ module Hanami
         self
       end
 
-      # Convert in-place all the keys to Symbol instances, nested hashes are converted too.
+      # Converts in-place all the keys to Symbol instances, nested hashes are converted too.
       #
       # @return [Hash] self
       #
@@ -315,7 +315,7 @@ module Hanami
         self
       end
 
-      # Return a deep copy of the current Hanami::Utils::Hash
+      # Returns a deep copy of the current Hanami::Utils::Hash
       #
       # @return [Hash] a deep duplicated self
       #
@@ -498,7 +498,7 @@ module Hanami
         @hash.inspect
       end
 
-      # Override Ruby's method_missing in order to provide ::Hash interface
+      # Overrides Ruby's method_missing in order to provide ::Hash interface
       #
       # @api private
       # @since 0.3.0
@@ -512,7 +512,7 @@ module Hanami
         h
       end
 
-      # Override Ruby's respond_to_missing? in order to support ::Hash interface
+      # Overrides Ruby's respond_to_missing? in order to support ::Hash interface
       #
       # @api private
       # @since 0.3.0

--- a/lib/hanami/utils/inflector.rb
+++ b/lib/hanami/utils/inflector.rb
@@ -314,7 +314,7 @@ module Hanami
         class_eval(&blk)
       end
 
-      # Add a custom inflection exception
+      # Adds a custom inflection exception
       #
       # @param [String] singular form
       # @param [String] plural form
@@ -345,7 +345,7 @@ module Hanami
         Inflecto.inflections.irregular(singular, plural)
       end
 
-      # Add an uncountable word
+      # Adds an uncountable word
       #
       # @param [Array<String>] words
       #
@@ -366,7 +366,7 @@ module Hanami
         end
       end
 
-      # Pluralize the given string
+      # Pluralizes the given string
       #
       # @param string [String] a string to pluralize
       #
@@ -424,7 +424,7 @@ module Hanami
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/MethodLength
 
-      # Singularize the given string
+      # Singularizes the given string
       #
       # @param string [String] a string to singularize
       #

--- a/lib/hanami/utils/json.rb
+++ b/lib/hanami/utils/json.rb
@@ -41,7 +41,7 @@ module Hanami
       end
       # rubocop:enable Style/ClassVars
 
-      # Parse the given JSON paylod
+      # Parses the given JSON paylod
       #
       # @param payload [String] a JSON payload
       #

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -7,7 +7,7 @@ require 'hanami/utils'
 require 'hanami/utils/string'
 
 unless defined?(Boolean)
-  # Define top level constant Boolean, so it can be easily used by other libraries
+  # Defines top level constant Boolean, so it can be easily used by other libraries
   # in coercions DSLs
   #
   # @since 0.3.0
@@ -1021,7 +1021,7 @@ module Hanami
         raise TypeError.new "can't convert #{inspect_type_error(arg)}into Symbol"
       end
 
-      # Check if the given argument is a string representation of a number
+      # Checks if the given argument is a string representation of a number
       #
       # @param arg [Object] the input
       #

--- a/lib/hanami/utils/load_paths.rb
+++ b/lib/hanami/utils/load_paths.rb
@@ -48,7 +48,7 @@ module Hanami
         @paths = original.instance_variable_get(:@paths).dup
       end
 
-      # Iterates thru the collection and yields the given block.
+      # Iterates through the collection and yields the given block.
       # It skips duplications and raises an error in case one of the paths
       # doesn't exist.
       #
@@ -156,7 +156,7 @@ module Hanami
 
       private
 
-      # Allow subclasses to define their own policy to discover the realpath
+      # Allows subclasses to define their own policy to discover the realpath
       # of the given path.
       #
       # @since 0.2.0

--- a/lib/hanami/utils/query_string.rb
+++ b/lib/hanami/utils/query_string.rb
@@ -12,7 +12,7 @@ module Hanami
       # @api private
       HASH_SEPARATOR = ","
 
-      # Serialize input into a query string
+      # Serializes input into a query string
       #
       # @param input [Object] the input
       #

--- a/lib/hanami/utils/shell_color.rb
+++ b/lib/hanami/utils/shell_color.rb
@@ -18,7 +18,7 @@ module Hanami
         end
       end
 
-      # Escape codes for terminals to output strings in colors
+      # Escapes codes for terminals to output strings in colors
       #
       # @since 1.2.0
       # @api private
@@ -33,7 +33,7 @@ module Hanami
         gray:    37,
       ].freeze
 
-      # Colorize output
+      # Colorizes output
       # 8 colors available: black, red, green, yellow, blue, magenta, cyan, and gray
       #
       # @param input [#to_s] the string to colorize

--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -79,7 +79,7 @@ module Hanami
       extend Transproc::Registry
       extend Transproc::Composer
 
-      # Apply the given transformation(s) to `input`
+      # Applies the given transformation(s) to `input`
       #
       # It performs a pipeline of transformations, by applying the given functions from `Hanami::Utils::String` and `::String`.
       # The transformations are applied in the given order.
@@ -164,7 +164,7 @@ module Hanami
         binding.instance_exec(value, &fun)
       end
 
-      # Return a titleized version of the string
+      # Returns a titleized version of the string
       #
       # @param input [::String] the input
       #
@@ -181,7 +181,7 @@ module Hanami
         underscore(string).split(CLASSIFY_SEPARATOR).map(&:capitalize).join(TITLEIZE_SEPARATOR)
       end
 
-      # Return a capitalized version of the string
+      # Returns a capitalized version of the string
       #
       # @param input [::String] the input
       #
@@ -208,7 +208,7 @@ module Hanami
         tail.unshift(head.capitalize).join(CAPITALIZE_SEPARATOR)
       end
 
-      # Return a CamelCase version of the string
+      # Returns a CamelCase version of the string
       #
       # @param input [::String] the input
       #
@@ -232,7 +232,7 @@ module Hanami
         words.zip(delimiters).join
       end
 
-      # Return a downcased and underscore separated version of the string
+      # Returns a downcased and underscore separated version of the string
       #
       # Revised version of `ActiveSupport::Inflector.underscore` implementation
       # @see https://github.com/rails/rails/blob/feaa6e2048fe86bcf07e967d6e47b865e42e055b/activesupport/lib/active_support/inflector/methods.rb#L90
@@ -257,7 +257,7 @@ module Hanami
         string.downcase
       end
 
-      # Return a downcased and dash separated version of the string
+      # Returns a downcased and dash separated version of the string
       #
       # @param input [::String] the input
       #
@@ -278,7 +278,7 @@ module Hanami
         underscore(string).split(CLASSIFY_SEPARATOR).join(DASHERIZE_SEPARATOR)
       end
 
-      # Return the string without the Ruby namespace of the class
+      # Returns the string without the Ruby namespace of the class
       #
       # @param input [::String] the input
       #
@@ -296,7 +296,7 @@ module Hanami
         ::String.new(input.to_s).split(NAMESPACE_SEPARATOR).last
       end
 
-      # Return the top level namespace name
+      # Returns the top level namespace name
       #
       # @param input [::String] the input
       #
@@ -314,7 +314,7 @@ module Hanami
         ::String.new(input.to_s).split(NAMESPACE_SEPARATOR).first
       end
 
-      # Return a pluralized version of self.
+      # Returns a pluralized version of self.
       #
       # @param input [::String] the input
       #
@@ -334,7 +334,7 @@ module Hanami
         Inflector.pluralize(string)
       end
 
-      # Return a singularized version of self.
+      # Returns a singularized version of self.
       #
       # @param input [::String] the input
       #
@@ -354,7 +354,7 @@ module Hanami
         Inflector.singularize(string)
       end
 
-      # Replace the rightmost match of `pattern` with `replacement`
+      # Replaces the rightmost match of `pattern` with `replacement`
       #
       # If the pattern cannot be matched, it returns the original string.
       #
@@ -396,7 +396,7 @@ module Hanami
         @string = string.to_s
       end
 
-      # Return a titleized version of the string
+      # Returns a titleized version of the string
       #
       # @return [Hanami::Utils::String] the transformed string
       #
@@ -412,7 +412,7 @@ module Hanami
         self.class.new underscore.split(CLASSIFY_SEPARATOR).map(&:capitalize).join(TITLEIZE_SEPARATOR)
       end
 
-      # Return a capitalized version of the string
+      # Returns a capitalized version of the string
       #
       # @return [Hanami::Utils::String] the transformed string
       #
@@ -444,7 +444,7 @@ module Hanami
         )
       end
 
-      # Return a CamelCase version of the string
+      # Returns a CamelCase version of the string
       #
       # @return [Hanami::Utils::String] the transformed string
       #
@@ -467,7 +467,7 @@ module Hanami
         self.class.new words.zip(delimiters).join
       end
 
-      # Return a downcased and underscore separated version of the string
+      # Returns a downcased and underscore separated version of the string
       #
       # Revised version of `ActiveSupport::Inflector.underscore` implementation
       # @see https://github.com/rails/rails/blob/feaa6e2048fe86bcf07e967d6e47b865e42e055b/activesupport/lib/active_support/inflector/methods.rb#L90
@@ -491,7 +491,7 @@ module Hanami
         self.class.new new_string
       end
 
-      # Return a downcased and dash separated version of the string
+      # Returns a downcased and dash separated version of the string
       #
       # @return [Hanami::Utils::String] the transformed string
       #
@@ -513,7 +513,7 @@ module Hanami
         self.class.new underscore.split(CLASSIFY_SEPARATOR).join(DASHERIZE_SEPARATOR)
       end
 
-      # Return the string without the Ruby namespace of the class
+      # Returns the string without the Ruby namespace of the class
       #
       # @return [Hanami::Utils::String] the transformed string
       #
@@ -532,7 +532,7 @@ module Hanami
         self.class.new split(NAMESPACE_SEPARATOR).last
       end
 
-      # Return the top level namespace name
+      # Returns the top level namespace name
       #
       # @return [Hanami::Utils::String] the transformed string
       #
@@ -590,7 +590,7 @@ module Hanami
       end
       # rubocop:enable Metrics/MethodLength
 
-      # Return a pluralized version of self.
+      # Returns a pluralized version of self.
       #
       # @return [Hanami::Utils::String] the pluralized string.
       #
@@ -603,7 +603,7 @@ module Hanami
         self.class.new Inflector.pluralize(self)
       end
 
-      # Return a singularized version of self.
+      # Returns a singularized version of self.
       #
       # @return [Hanami::Utils::String] the singularized string.
       #
@@ -650,7 +650,7 @@ module Hanami
 
       alias eql? ==
 
-      # Split the string with the given pattern
+      # Splits the string with the given pattern
       #
       # @return [Array<::String>]
       #
@@ -662,7 +662,7 @@ module Hanami
         @string.split(pattern, limit)
       end
 
-      # Replace the given pattern with the given replacement
+      # Replaces the given pattern with the given replacement
       #
       # @return [::String]
       #
@@ -678,7 +678,7 @@ module Hanami
         end
       end
 
-      # Iterate through the string, matching the pattern.
+      # Iterates through the string, matching the pattern.
       # Either return all those patterns, or pass them to the block.
       #
       # @return [Array<::String>]
@@ -691,7 +691,7 @@ module Hanami
         @string.scan(pattern, &blk)
       end
 
-      # Replace the rightmost match of `pattern` with `replacement`
+      # Replaces the rightmost match of `pattern` with `replacement`
       #
       # If the pattern cannot be matched, it returns the original string.
       #
@@ -726,7 +726,7 @@ module Hanami
         end
       end
 
-      # Override Ruby's method_missing in order to provide ::String interface
+      # Overrides Ruby's method_missing in order to provide ::String interface
       #
       # @api private
       # @since 0.3.0
@@ -740,7 +740,7 @@ module Hanami
         s
       end
 
-      # Override Ruby's respond_to_missing? in order to support ::String interface
+      # Overrides Ruby's respond_to_missing? in order to support ::String interface
       #
       # @api private
       # @since 0.3.0


### PR DESCRIPTION
I have noticed, different methods are using different approach to describe. The purpose ("to do smth") vs. the action ("does smth").
With this PR I tried to make it more consistent across the files. 