### PR TITLE
Don't check breakline if file is empty.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,31 @@ jobs:
           name: run tests
           command: |
             ./script/ci
+  "ruby-2.7":
+    docker:
+       - image: hanami/ruby-2.7
+    working_directory: ~/hanami-utils
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            ./script/ci
   "jruby-9.1":
     docker:
        - image: hanami/jruby-9.1
@@ -163,5 +188,6 @@ workflows:
       - "ruby-2.4"
       - "ruby-2.5"
       - "ruby-2.6"
+      - "ruby-2.7"
       - "jruby-9.1"
       - "jruby-9.2"

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,52 @@
 kind: pipeline
+name: ruby-2-7
+group: build
+
+steps:
+- name: install
+  image: ruby:2.7
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.7
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: isolation
+  image: ruby:2.7
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ./script/test isolation
+
+- name: quality
+  image: ruby:2.7
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
 name: ruby-2-6
 group: build
 
@@ -196,7 +244,7 @@ group: build
 
 steps:
 - name: install
-  image: jruby:9.2
+  image: hanami/jruby-9.2
   volumes:
   - name: bundle
     path: /usr/local/bundle
@@ -206,7 +254,7 @@ steps:
   - bundle install --jobs=3 --retry=3
 
 - name: unit
-  image: jruby:9.2
+  image: hanami/jruby-9.2
   volumes:
   - name: bundle
     path: /usr/local/bundle
@@ -214,7 +262,7 @@ steps:
   - COVERAGE=true bundle exec rake spec:unit
 
 - name: quality
-  image: jruby:9.2
+  image: hanami/jruby-9.2
   environment:
     CODECOV_TOKEN:
       from_secret: codecov
@@ -236,7 +284,7 @@ group: build
 
 steps:
 - name: install
-  image: jruby:9.1
+  image: hanami/jruby-9.1
   volumes:
   - name: bundle
     path: /usr/local/bundle
@@ -246,7 +294,7 @@ steps:
   - bundle install --jobs=3 --retry=3
 
 - name: unit
-  image: jruby:9.1
+  image: hanami/jruby-9.1
   volumes:
   - name: bundle
     path: /usr/local/bundle
@@ -254,7 +302,7 @@ steps:
   - COVERAGE=true bundle exec rake spec:unit
 
 - name: isolation
-  image: jruby:9.1
+  image: hanami/jruby-9.1
   volumes:
   - name: bundle
     path: /usr/local/bundle
@@ -262,7 +310,7 @@ steps:
   - ./script/test isolation
 
 - name: quality
-  image: jruby:9.1
+  image: hanami/jruby-9.1
   environment:
     CODECOV_TOKEN:
       from_secret: codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.0
+  - 2.7.0
   - jruby-9.1.9.0
   - ruby-head
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 sudo: false
 cache: bundler
+before_install:
+  - travis_retry gem update --system || travis_retry gem update --system 2.7.8
+  - travis_retry gem install bundler --no-document || travis_retry gem install bundler --no-document -v 1.17.3
 before_script:
   - gem update --system
 script: ./script/ci

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 
 gem 'gson', '>= 0.6', require: false, platforms: :jruby
 
-gem 'rubocop', '~> 0.77.0', require: false
+gem 'rubocop', '~> 0.78.0', require: false
 gem 'codecov', require: false, group: :test

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -163,7 +163,7 @@ module Hanami
         mkdir_p(path)
 
         content = ::File.readlines(path)
-        content << "\n" if content.any? && !content.last.end_with?("\n")
+        content << "\n" if _append_newline?(content)
         content << "#{contents}\n"
 
         write(path, content)
@@ -452,6 +452,16 @@ module Hanami
       end
 
       private_class_method :line_number
+
+      # @since 1.3.6
+      # @api private
+      def self._append_newline?(content)
+        return false if content.empty?
+
+        !content.last.end_with?("\n")
+      end
+
+      private_class_method :_append_newline?
     end
   end
 end

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -163,7 +163,7 @@ module Hanami
         mkdir_p(path)
 
         content = ::File.readlines(path)
-        content << "\n" unless content.last.end_with?("\n")
+        content << "\n" if content.any? && !content.last.end_with?("\n")
         content << "#{contents}\n"
 
         write(path, content)

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -1042,11 +1042,11 @@ module Hanami
       # @since 0.4.3
       # @api private
       def self.inspect_type_error(arg)
-        (arg.respond_to?(:inspect) ? arg.inspect : arg.to_s) << ' '
+        (arg.respond_to?(:inspect) ? arg.inspect : arg.to_s) + ' '
       rescue NoMethodError
         # missing the #respond_to? method, fall back to returning the class' name
         begin
-          arg.class.name << ' instance '
+          arg.class.name + ' instance '
         rescue NoMethodError
           # missing the #class method, can't fall back to anything better than nothing
           # Callers will have to guess from their code

--- a/spec/support/stdout.rb
+++ b/spec/support/stdout.rb
@@ -1,3 +1,5 @@
+require 'stringio'
+
 module RSpec
   module Support
     module Stdout

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -308,6 +308,20 @@ RSpec.describe Hanami::Utils::Files do
       expect(path).to have_content(expected)
     end
 
+    it "adds a line to empty file" do
+      path = root.join("append_empty_file.rb")
+      content = ""
+
+      described_class.write(path, content)
+      described_class.append(path, "get '/tires', to: 'sunshine#index'")
+
+      expected = <<~EOF
+        get '/tires', to: 'sunshine#index'
+      EOF
+
+      expect(path).to have_content(expected)
+    end
+
     it "raises error if path doesn't exist" do
       path = root.join("append_no_exist.rb")
 


### PR DESCRIPTION
Hey.
I use `hanami-reloader` but I got the below error messages.

```
undefined method `end_with?' for nil:NilClass
/Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/hanami-utils-1.3.5/lib/hanami/utils/files.rb:166:in `append'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/hanami-reloader-0.2.1/lib/hanami/reloader/cli.rb:16:in `call'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/hanami-1.3.3/lib/hanami/cli/commands/command.rb:85:in `call'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/hanami-cli-0.3.1/lib/hanami/cli.rb:57:in `call'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/hanami-1.3.3/bin/hanami:6:in `<top (required)>'
        /Users/ippachi/.rbenv/versions/2.6.5/bin/hanami:23:in `load'
        /Users/ippachi/.rbenv/versions/2.6.5/bin/hanami:23:in `<top (required)>'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `load'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `kernel_load'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:28:in `run'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli.rb:463:in `exec'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli.rb:27:in `dispatch'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli.rb:18:in `start'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:30:in `block in <top (required)>'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/friendly_errors.rb:124:in `with_friendly_errors'
        /Users/ippachi/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:22:in `<top (required)>'
        /Users/ippachi/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
        /Users/ippachi/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'
```

This exception is caused that `Utils::Files.append` doesn't support empty file.
So fix it.
Thanks! 😄 