### PR TITLE
Consider keyword arguments in the interactor.

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -355,7 +355,15 @@ module Hanami
       #   Signup.new.call # => NoMethodError
       def call(*args)
         @__result = ::Hanami::Interactor::Result.new
-        _call(*args) { super }
+        _call(*args) do
+          if method(:call).super_method.parameters.last[0] == :keyrest &&
+             args.last.respond_to?(:to_hash)
+            kwargs = args.pop
+            super(*args, **kwargs)
+          else
+            super(*args)
+          end
+        end
       end
 
       private

--- a/spec/unit/hanami/interactor_spec.rb
+++ b/spec/unit/hanami/interactor_spec.rb
@@ -294,13 +294,13 @@ class CreateUser
   expose :user
 
   def call(**params)
-    build_user(params)
+    build_user(**params)
     persist
   end
 
   private
 
-  def build_user(params)
+  def build_user(**params)
     @user = User.new(params)
   end
 


### PR DESCRIPTION
```
require 'hanami/interactor'

class A
  include Hanami::Interactor
  def call(test, a:, b:)
    puts test, a, b
  end
end

A.new.call({ test: 1 }, a: 2, b: 3)
```

This code output warning about the keyword argument of ruby 2.7.
So I declared the keyword argument explicitly.