### PR TITLE
Change archived gem "Transproc" for its successor "Dry::Transformer"

### DIFF
--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "transproc",       "~> 1.0"
+  spec.add_dependency "dry-transformer", "~> 0.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"

--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require "transproc"
+require "dry-transformer"
 
 module Hanami
   module Utils
     # Hash transformations
     # @since 0.1.0
     module Hash
-      extend Transproc::Registry
-      import Transproc::HashTransformations
+      extend Dry::Transformer::Registry
+      import Dry::Transformer::HashTransformations
 
       # Symbolize the given hash
       #
@@ -91,19 +91,7 @@ module Hanami
       #   hash.class
       #     # => Hash
       def self.deep_stringify(input)
-        input.each_with_object({}) do |(key, value), output|
-          output[key.to_s] =
-            case value
-            when ::Hash
-              deep_stringify(value)
-            when Array
-              value.map do |item|
-                item.is_a?(::Hash) ? deep_stringify(item) : item
-              end
-            else
-              value
-            end
-        end
+        self[:deep_stringify_keys].call(input)
       end
 
       # Deep duplicates hash values


### PR DESCRIPTION
Hi, I was looking at the **Utils::Hash** class in the `unstable` branch and noticed that they are using the gem "transport" that was archived and is now "dry-transformer".

I checked the trello (Hanami 2.0) just in case and did not see any tasks planned for this change

I changed the gem and made some small changes to fit the gem Dry::Transformer.