### PR TITLE
Allows Logger can filter an array of hash

### DIFF
--- a/spec/unit/hanami/logger_spec.rb
+++ b/spec/unit/hanami/logger_spec.rb
@@ -660,15 +660,15 @@ RSpec.describe Hanami::Logger do
     end
 
     it "doesn't mutate the input hash" do
-      input = Hash["password" => "azerty", foo: Hash[password: "bar"]]
+      input = Hash[password: "azerty", foo: Hash[password: "bar"]]
       described_class.new(%w[password]).call(input)
-      expect(input).to eql(Hash["password" => "azerty", foo: Hash[password: "bar"]])
+      expect(input).to eql(Hash[password: "azerty", foo: Hash[password: "bar"]])
     end
 
     it "doesn't mutate the input array" do
-      input = Array[Hash["password" => "azerty", foo: Hash[password: "bar"]]]
+      input = Array[Hash[password: "azerty", foo: Hash[password: "bar"]]]
       described_class.new(%w[password]).call(input)
-      expect(input).to eql(Array[Hash["password" => "azerty", foo: Hash[password: "bar"]]])
+      expect(input).to eql(Array[Hash[password: "azerty", foo: Hash[password: "bar"]]])
     end
 
     it "filters an array of hash" do
@@ -700,10 +700,10 @@ RSpec.describe Hanami::Logger do
     end
 
     context "when input has Tempfile" do
-      let(:tempfile) { Tempfile.new("filter_test") }
-      after { tempfile.close! }
-
       it "filters without errors with closed stream" do
+        tempfile = Tempfile.new("filter_test")
+        tempfile.close!
+
         input = Hash[password: "password", file: tempfile]
         output = described_class.new(%i[password file]).call(input)
         expect(output).to eql(Hash[password: "[FILTERED]", file: "[FILTERED]"])


### PR DESCRIPTION
Currently, the `Logger` support filter only for a single hash. In case the input sent to the logger is an array of hash, the input does not filter as expected.

Before:
- Input
```ruby
[{:password=>"foo", :user=>{:name=>"foo", :password=>"abc"}}, {:password=>"bar", :user=>{:name=>"bar", :password=>"xyz"}}]
```
- Output
```ruby
[{:password=>"foo", :user=>{:name=>"foo", :password=>"abc"}}, {:password=>"bar", :user=>{:name=>"bar", :password=>"xyz"}}]
```

After:
- Input
```ruby
[{:password=>"foo", :user=>{:name=>"foo", :password=>"abc"}}, {:password=>"bar", :user=>{:name=>"bar", :password=>"xyz"}}]
```
- Output
```ruby
[{:password=>"foo", :user=>{:name=>"foo", :password=>"[FILTERED]"}}, {:password=>"bar", :user=>{:name=>"bar", :password=>"[FILTERED]"}}
```