### PR TITLE
Allow keyword arguments in interactor initializer for ruby 3

### DIFF
--- a/lib/hanami/interactor.rb
+++ b/lib/hanami/interactor.rb
@@ -181,10 +181,18 @@ module Hanami
       #       # ...
       #     end
       #   end
-      def initialize(*args)
-        super
-      ensure
-        @__result = ::Hanami::Interactor::Result.new
+      if RUBY_VERSION >= "3.0"
+        def initialize(*args, **kwargs)
+          super
+        ensure
+          @__result = ::Hanami::Interactor::Result.new
+        end
+      else
+        def initialize(*args)
+          super
+        ensure
+          @__result = ::Hanami::Interactor::Result.new
+        end
       end
 
       # Triggers the operation and return a result.

--- a/spec/unit/hanami/interactor_spec.rb
+++ b/spec/unit/hanami/interactor_spec.rb
@@ -274,8 +274,8 @@ class LegacyCreateUser
   include Hanami::Interactor
   expose :user
 
-  def initialize(params)
-    @user = User.new(params)
+  def initialize(**params)
+    @user = User.new(**params)
   end
 
   def call
@@ -317,8 +317,8 @@ class CreateUser
 end
 
 class LegacyUpdateUser < LegacyCreateUser
-  def initialize(_user, params)
-    super(params)
+  def initialize(_user, **params)
+    super(**params)
     @user.name = params.fetch(:name)
   end
 end


### PR DESCRIPTION
I have an interactor like this:

```ruby
class CreateUser
  include Hanami::Interactor

  def initialize(user_repo: UserRepository.new)
    @user_repo = user_repo
  end

  def call(**params)
    user_repo.create(params)
  end
end
```
When upgrade to ruby 3, this interactor raises `ArgumentError: wrong number of arguments (given 1, expected 0)` when initialized.