### PR TITLE
`Hanami::Logger`: allow for to specify `File::NULL` as `stream:`

### DIFF
--- a/lib/hanami/logger.rb
+++ b/lib/hanami/logger.rb
@@ -354,6 +354,8 @@ module Hanami
     # @since 1.2.0
     # @api private
     def tty?
+      return false if @logdev.nil?
+
       @logdev.dev.tty?
     end
   end

--- a/spec/unit/hanami/logger_spec.rb
+++ b/spec/unit/hanami/logger_spec.rb
@@ -251,6 +251,17 @@ RSpec.describe Hanami::Logger do
         end
       end
 
+      describe "when File::NULL" do
+        let(:stream) { File::NULL }
+
+        it "does not throw error" do
+          expect {
+            logger = Hanami::Logger.new(stream: stream)
+            logger.info("in null file")
+          }.not_to raise_error
+        end
+      end
+
       describe "when StringIO" do
         let(:stream) { StringIO.new }
 


### PR DESCRIPTION
If the `stream` is set to `File::NULL`, `@logdev` will be `nil`

This is due to the following logic in `Logger#initialize`
https://github.com/ruby/logger/blob/cdeddb2f6721e9003d71a7013d68733dd992b0d6/lib/logger.rb#L388-L394

The use case for this is if you wish to "throw away" any logs without
polluting stdout or a logfile. Perhaps in testing for instance where you might want `Hanami::Logger.new(stream: "/dev/null")`