### PR TITLE
Move `Hanami.env` and `Hanami.env?` into `Hanami::Utils`

### DIFF
--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -46,7 +46,6 @@ module Hanami
     # @return [Symbol] env
     #
     # @since 2.0.0
-    # @api private
     def self.env
       ENV.fetch("HANAMI_ENV", "development").to_sym
     end
@@ -55,10 +54,9 @@ module Hanami
     #
     # @param [Array<String, Symbol>] list of environment names
     #
-    # @return [TrueClass,FalseClass]
+    # @return [Boolean]
     #
     # @since 2.0.0
-    # @api private
     def self.env?(*names)
       names.map(&:to_sym).include?(env)
     end

--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -41,6 +41,28 @@ module Hanami
       RUBY_ENGINE == HANAMI_RUBINIUS
     end
 
+    # Returns symbolized HANAMI_ENV or defaults to `:development`
+    #
+    # @return [Symbol] env
+    #
+    # @since 2.0.0
+    # @api private
+    def self.env
+      ENV.fetch("HANAMI_ENV", "development").to_sym
+    end
+
+    # Checks whether current Hanami env is matching one of the given names
+    #
+    # @param [Array<String, Symbol>] list of environment names
+    #
+    # @return [TrueClass,FalseClass]
+    #
+    # @since 2.0.0
+    # @api private
+    def self.env?(*names)
+      names.map(&:to_sym).include?(env)
+    end
+
     # Recursively requires Ruby files under the given directory.
     #
     # If the directory is relative, it implies it's the path from current directory.

--- a/spec/unit/hanami/utils/utils_spec.rb
+++ b/spec/unit/hanami/utils/utils_spec.rb
@@ -20,4 +20,34 @@ RSpec.describe Hanami::Utils do
       end
     end
   end
+
+  describe ".env" do
+    context "when HANAMI_ENV is not given" do
+      it "returns :development" do
+        expect(Hanami::Utils.env).to eq(:development)
+      end
+    end
+
+    context "when HANAMI_ENV is given" do
+      before do
+        allow(ENV).to receive(:fetch).with("HANAMI_ENV", "development").and_return("production")
+      end
+
+      it "returns symbolized HANAMI_ENV" do
+        expect(Hanami::Utils.env).to eq(:production)
+      end
+    end
+  end
+
+  describe ".env?" do
+    it "returns true" do
+      expect(Hanami::Utils.env?("development", "test")).to eq(true)
+    end
+
+    context "when given names does not match HANAMI_ENV" do
+      it "returns false" do
+        expect(Hanami::Utils.env?("production")).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Tracked by https://trello.com/c/dpt5iSkY/108-add-hanamienv-and-hanamienv-to-hanami-utils-so-we-can-rely-on-them-in-gems-like-hanami-controller-when-they-are-used-standalone

Let me know whether you would like to have those methods defined in `Hanami::Utils::Env` instead of the root `Hanami::Utils` module.