### PR TITLE
Convert to Zeitwerk for code loading

### DIFF
--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "dry-transformer", "~> 0.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 13"

--- a/lib/hanami-utils.rb
+++ b/lib/hanami-utils.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "hanami/utils"
+require_relative "hanami/utils"

--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -1,18 +1,33 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "zeitwerk"
 
 # Hanami - The web, with simplicity
 #
 # @since 0.1.0
 module Hanami
-  require "hanami/utils/version"
-  require "hanami/utils/file_list"
-
   # Ruby core extentions and Hanami utilities
   #
   # @since 0.1.0
   module Utils
+    # @since 2.0.0
+    # @api private
+    def self.gem_loader
+      @gem_loader ||= Zeitwerk::Loader.new.tap do |loader|
+        root = File.expand_path("..", __dir__)
+        loader.tag = "hanami-utils"
+        loader.inflector = Zeitwerk::GemInflector.new("#{root}/hanami-utils.rb")
+        loader.push_dir(root)
+        loader.ignore(
+          "#{root}/hanami-utils.rb"
+        )
+        loader.inflector.inflect("io" => "IO")
+      end
+    end
+
+    gem_loader.setup
+
     # @since 0.3.1
     # @api private
     HANAMI_JRUBY = "java"

--- a/lib/hanami/utils/deprecation.rb
+++ b/lib/hanami/utils/deprecation.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils"
-
 module Hanami
   module Utils
     # Prints a deprecation warning when initialized

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -2,7 +2,6 @@
 
 require "pathname"
 require "fileutils"
-require "hanami/utils/deprecation"
 
 module Hanami
   module Utils

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -5,8 +5,6 @@ require "date"
 require "time"
 require "pathname"
 require "bigdecimal"
-require "hanami/utils"
-require "hanami/utils/string"
 
 unless defined?(Boolean)
   # Defines top level constant Boolean, so it can be easily used by other libraries

--- a/lib/hanami/utils/load_paths.rb
+++ b/lib/hanami/utils/load_paths.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/kernel"
-
 module Hanami
   module Utils
     # A collection of loading paths.

--- a/lib/hanami/utils/path_prefix.rb
+++ b/lib/hanami/utils/path_prefix.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/kernel"
-
 module Hanami
   module Utils
     # Prefixed string

--- a/spec/isolation/hanami/utils/json/json_spec.rb
+++ b/spec/isolation/hanami/utils/json/json_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
-require "hanami/utils/json"
 
 RSpec.describe Hanami::Utils::Json do
   describe "with JSON" do

--- a/spec/support/silence_deprecations.rb
+++ b/spec/support/silence_deprecations.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rspec"
-require "hanami/utils/io"
 
 RSpec.configure do |config|
   config.around(:example, silence_deprecations: true) do |example|

--- a/spec/unit/hanami/utils/blank_spec.rb
+++ b/spec/unit/hanami/utils/blank_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/kernel"
-require "hanami/utils/blank"
-
 RSpec.describe Hanami::Utils::Blank do
   describe ".blank?" do
     [nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}, Set.new,

--- a/spec/unit/hanami/utils/callbacks_spec.rb
+++ b/spec/unit/hanami/utils/callbacks_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/callbacks"
-
 Hanami::Utils::Callbacks::Chain.class_eval do
   def size
     @chain.size

--- a/spec/unit/hanami/utils/class_attribute/attributes_spec.rb
+++ b/spec/unit/hanami/utils/class_attribute/attributes_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/class_attribute/attributes"
-
 RSpec.describe Hanami::Utils::ClassAttribute::Attributes do
   subject { described_class.new }
 

--- a/spec/unit/hanami/utils/class_attribute_spec.rb
+++ b/spec/unit/hanami/utils/class_attribute_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/class_attribute"
-
 RSpec.describe Hanami::Utils::ClassAttribute do
   before do
     class ClassAttributeTest

--- a/spec/unit/hanami/utils/class_spec.rb
+++ b/spec/unit/hanami/utils/class_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/class"
-require "hanami/utils/io"
-
 RSpec.describe Hanami::Utils::Class do
   before do
     Hanami::Utils::IO.silence_warnings do

--- a/spec/unit/hanami/utils/deprecation_spec.rb
+++ b/spec/unit/hanami/utils/deprecation_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/deprecation"
-
 class DeprecationTest
   def old_method
     Hanami::Utils::Deprecation.new("old_method is deprecated, please use new_method")
@@ -25,11 +23,11 @@ end
 RSpec.describe Hanami::Utils::Deprecation do
   it "prints a deprecation warning for direct call" do
     expect { DeprecationTest.new.old_method }
-      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:27")).to_stderr
+      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:25")).to_stderr
   end
 
   it "prints a deprecation warning for nested call" do
     expect { DeprecationWrapperTest.new.run }
-      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:21:in `run'.")).to_stderr
+      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:19:in `run'.")).to_stderr
   end
 end

--- a/spec/unit/hanami/utils/escape_spec.rb
+++ b/spec/unit/hanami/utils/escape_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils"
-require "hanami/utils/escape"
 require "date"
 
 RSpec.describe Hanami::Utils::Escape do

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/utils/files"
 require "securerandom"
-require "hanami/utils/io"
 
 RSpec.describe Hanami::Utils::Files do
   let(:root) { Pathname.new(Dir.pwd).join("tmp", SecureRandom.uuid).tap(&:mkpath) }

--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -2,7 +2,6 @@
 
 require "bigdecimal"
 require "ostruct"
-require "hanami/utils/hash"
 
 RSpec.describe Hanami::Utils::Hash do
   describe ".symbolize" do

--- a/spec/unit/hanami/utils/io_spec.rb
+++ b/spec/unit/hanami/utils/io_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/io"
-
 class IOTest
   TEST_CONSTANT = "initial"
 end

--- a/spec/unit/hanami/utils/kernel_spec.rb
+++ b/spec/unit/hanami/utils/kernel_spec.rb
@@ -3,7 +3,6 @@
 require "ostruct"
 require "bigdecimal"
 require "securerandom"
-require "hanami/utils/kernel"
 
 # rubocop:disable Style/OpenStructUse
 RSpec.describe Hanami::Utils::Kernel do

--- a/spec/unit/hanami/utils/load_paths_spec.rb
+++ b/spec/unit/hanami/utils/load_paths_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/load_paths"
-
 Hanami::Utils::LoadPaths.class_eval do
   def empty?
     @paths.empty?

--- a/spec/unit/hanami/utils/path_prefix_spec.rb
+++ b/spec/unit/hanami/utils/path_prefix_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/path_prefix"
-
 RSpec.describe Hanami::Utils::PathPrefix do
   it "exposes itself as a string" do
     prefix = Hanami::Utils::PathPrefix.new

--- a/spec/unit/hanami/utils/query_string_spec.rb
+++ b/spec/unit/hanami/utils/query_string_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/query_string"
 require "bigdecimal"
 
 RSpec.describe Hanami::Utils::QueryString do

--- a/spec/unit/hanami/utils/shell_color_spec.rb
+++ b/spec/unit/hanami/utils/shell_color_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/shell_color"
-
 RSpec.describe Hanami::Utils::ShellColor do
   describe ".call" do
     it "returns a string wrapped with black's code" do

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/string"
-
 RSpec.describe Hanami::Utils::String do
   describe ".transform" do
     it "applies multiple transformations" do


### PR DESCRIPTION
Covert the gem to use Zeitwerk for code loading. To do this:

- Add zeitwerk to the gemspec
- Set up the Zeitwerk loader inside `lib/hanami/utils.rb` (following the same `.gem_loader`  name I've used in all the other Hanami gems I'm converting today, since it's clear and now consistent)
- Remove all now-unneeded manual requires for files inside the gem

Of all the zeitwerk conversions, this one _may_ result in some potential breakages since a cherry-picked require without a _previous_ require to `"hanami/utils"` will mean that Zeitwerk is not set up. However, since usage of hanami-utils is almost entirely in-ecosystem, we can sort out any issues in the next day or two.