### PR TITLE
Make chains comparable by #== based on contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Ruby core extensions and class utilities for Hanami
 
+## Unreleased
+
+### Changed
+
+- [Tim Riley] Make `Hanami::Utils::Callbacks::Chain` and `Hanami::Utils::Callbacks::Callback` comparable via `#==` based on their contents, rather than their object identity
+
 ## v2.0.0 - 2022-11-22
 
 ## v2.0.0.rc1 - 2022-11-08

--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.required_ruby_version = ">= 3.0"
 
+  spec.add_dependency "dry-core", "~> 1.0", "< 2"
   spec.add_dependency "dry-transformer", "~> 1.0", "< 2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
 

--- a/lib/hanami/utils/callbacks.rb
+++ b/lib/hanami/utils/callbacks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "concurrent/array"
+require "dry/core"
 
 module Hanami
   module Utils
@@ -14,6 +15,8 @@ module Hanami
       # @since 0.1.0
       # @private
       class Chain
+        include Dry.Equalizer(:chain)
+
         # Returns a new chain
         #
         # @return [Hanami::Utils::Callbacks::Chain]
@@ -235,6 +238,8 @@ module Hanami
       # @since 0.1.0
       # @api private
       class Callback
+        include Dry.Equalizer(:callback)
+
         # @api private
         attr_reader :callback
 

--- a/spec/unit/hanami/utils/callbacks_spec.rb
+++ b/spec/unit/hanami/utils/callbacks_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Hanami::Utils::Callbacks::Chain do
     end
 
     it "raises an error if try to add a callback when frozen" do
-      expect {  @chain.append :authenticate! }.to raise_error RuntimeError
+      expect { @chain.append :authenticate! }.to raise_error RuntimeError
     end
   end
 

--- a/spec/unit/hanami/utils/callbacks_spec.rb
+++ b/spec/unit/hanami/utils/callbacks_spec.rb
@@ -282,6 +282,17 @@ RSpec.describe Hanami::Utils::Callbacks::Chain do
       expect {  @chain.append :authenticate! }.to raise_error RuntimeError
     end
   end
+
+  describe "#==" do
+    it "is equal to another chain based on its contents" do
+      @chain.append :callback_a, :callback_b
+
+      other = @chain.class.new
+      other.append :callback_a, :callback_b
+
+      expect(@chain).to eq other
+    end
+  end
 end
 
 RSpec.describe Hanami::Utils::Callbacks::Factory do


### PR DESCRIPTION
This is useful behavior on its own, but is also necessary to ensure callbacks from a base app-level Hanami::Action class propogate all the way through a slice-level base class to an individual action class.

This adds dry-core to the list of gem dependencies to get access to its easy-to-use `Dry::Equalizer`. This feels like a reasonable addition given that dry-core is already going to be in the bundle for any project using Hanami gems.