### PR TITLE
reference target object instead of self in .blank?

### DIFF
--- a/lib/hanami/utils/blank.rb
+++ b/lib/hanami/utils/blank.rb
@@ -41,7 +41,7 @@ module Hanami
         when FalseClass, NilClass
           true
         else
-          object.respond_to?(:empty?) ? object.empty? : !self
+          object.respond_to?(:empty?) ? object.empty? : !object
         end
       end
 


### PR DESCRIPTION
Addresses https://github.com/hanami/utils/issues/408. It looks like part of the existing `blank?` implementation was copied from from the Active Support counterpart and was not properly updated to fit the new context.