### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "hanami/utils/version"

--- a/lib/hanami-utils.rb
+++ b/lib/hanami-utils.rb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 require "hanami/utils"

--- a/lib/hanami/middleware.rb
+++ b/lib/hanami/middleware.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # Shared Rack middleware for Hanami apps.
   #

--- a/lib/hanami/utils.rb
+++ b/lib/hanami/utils.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 
 # Hanami - The web, with simplicity

--- a/lib/hanami/utils/blank.rb
+++ b/lib/hanami/utils/blank.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Utils
     # Checks for blank

--- a/lib/hanami/utils/callbacks.rb
+++ b/lib/hanami/utils/callbacks.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "concurrent/array"
 require "dry/core"
 

--- a/lib/hanami/utils/class.rb
+++ b/lib/hanami/utils/class.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Utils
     # Class utilities

--- a/lib/hanami/utils/class_attribute.rb
+++ b/lib/hanami/utils/class_attribute.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Utils
     # Inheritable class level variable accessors.

--- a/lib/hanami/utils/class_attribute/attributes.rb
+++ b/lib/hanami/utils/class_attribute/attributes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "concurrent/map"
 
 module Hanami

--- a/lib/hanami/utils/deprecation.rb
+++ b/lib/hanami/utils/deprecation.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils"
 
 module Hanami

--- a/lib/hanami/utils/file_list.rb
+++ b/lib/hanami/utils/file_list.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Utils
     # Ordered file list, consistent across operating systems

--- a/lib/hanami/utils/files.rb
+++ b/lib/hanami/utils/files.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 require "fileutils"
 require "hanami/utils/deprecation"

--- a/lib/hanami/utils/hash.rb
+++ b/lib/hanami/utils/hash.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/transformer"
 
 module Hanami

--- a/lib/hanami/utils/io.rb
+++ b/lib/hanami/utils/io.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Utils
     # IO utils

--- a/lib/hanami/utils/json.rb
+++ b/lib/hanami/utils/json.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 begin
   require "multi_json"
 rescue LoadError

--- a/lib/hanami/utils/kernel.rb
+++ b/lib/hanami/utils/kernel.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "set"
 require "date"
 require "time"

--- a/lib/hanami/utils/load_paths.rb
+++ b/lib/hanami/utils/load_paths.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/kernel"
 
 module Hanami

--- a/lib/hanami/utils/path_prefix.rb
+++ b/lib/hanami/utils/path_prefix.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/kernel"
 
 module Hanami

--- a/lib/hanami/utils/query_string.rb
+++ b/lib/hanami/utils/query_string.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "cgi"
 
 module Hanami

--- a/lib/hanami/utils/shell_color.rb
+++ b/lib/hanami/utils/shell_color.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Utils
     # Shell helper for colorizing STDOUT

--- a/lib/hanami/utils/string.rb
+++ b/lib/hanami/utils/string.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/transformer"
 require "concurrent/map"
 

--- a/lib/hanami/utils/version.rb
+++ b/lib/hanami/utils/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Utils
     # The current hanami-utils version.

--- a/spec/isolation/hanami/utils/json/json_spec.rb
+++ b/spec/isolation/hanami/utils/json/json_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
 require "hanami/utils/json"
 

--- a/spec/isolation/hanami/utils/json/multi_json_spec.rb
+++ b/spec/isolation/hanami/utils/json/multi_json_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
 Bundler.require(:default, :development, :multi_json)
 

--- a/spec/isolation/hanami/utils/require/with_absolute_path_spec.rb
+++ b/spec/isolation/hanami/utils/require/with_absolute_path_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
 
 RSpec.describe "Hanami::Utils.require!" do

--- a/spec/isolation/hanami/utils/require/with_file_separator_spec.rb
+++ b/spec/isolation/hanami/utils/require/with_file_separator_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
 
 RSpec.describe "Hanami::Utils.require!" do

--- a/spec/isolation/hanami/utils/require/with_recursive_pattern_spec.rb
+++ b/spec/isolation/hanami/utils/require/with_recursive_pattern_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
 
 RSpec.describe "Hanami::Utils.require!" do

--- a/spec/isolation/hanami/utils/require/with_relative_path_spec.rb
+++ b/spec/isolation/hanami/utils/require/with_relative_path_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
 
 RSpec.describe "Hanami::Utils.require!" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if ENV["COVERALL"]
   require "coveralls"
   Coveralls.wear!

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if ENV["CI"]
   require "simplecov"
 

--- a/spec/support/files.rb
+++ b/spec/support/files.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rspec/expectations"
 
 RSpec::Matchers.define :have_content do |expected|

--- a/spec/support/fixtures/file_list/a.rb
+++ b/spec/support/fixtures/file_list/a.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 class A
 end

--- a/spec/support/fixtures/file_list/aa.rb
+++ b/spec/support/fixtures/file_list/aa.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 class Aa
 end

--- a/spec/support/fixtures/file_list/ab.rb
+++ b/spec/support/fixtures/file_list/ab.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 class Ab
 end

--- a/spec/support/fixtures/file_list/nested/c.rb
+++ b/spec/support/fixtures/file_list/nested/c.rb
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 class C
 end

--- a/spec/support/fixtures/fixtures.rb
+++ b/spec/support/fixtures/fixtures.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class WrappingHash
   def initialize(hash)
     @hash = hash.to_h

--- a/spec/support/isolation_spec_helper.rb
+++ b/spec/support/isolation_spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rubygems"
 require "bundler"
 Bundler.setup(:default, :development, :test)

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rspec"
 
 RSpec.configure do |config|

--- a/spec/support/silence_deprecations.rb
+++ b/spec/support/silence_deprecations.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rspec"
 require "hanami/utils/io"
 

--- a/spec/support/stdout.rb
+++ b/spec/support/stdout.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "stringio"
 
 module RSpec

--- a/spec/unit/hanami/middleware_spec.rb
+++ b/spec/unit/hanami/middleware_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware"
 
 RSpec.describe Hanami::Middleware do

--- a/spec/unit/hanami/utils/blank_spec.rb
+++ b/spec/unit/hanami/utils/blank_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/kernel"
 require "hanami/utils/blank"
 

--- a/spec/unit/hanami/utils/callbacks_spec.rb
+++ b/spec/unit/hanami/utils/callbacks_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/callbacks"
 
 Hanami::Utils::Callbacks::Chain.class_eval do

--- a/spec/unit/hanami/utils/class_attribute/attributes_spec.rb
+++ b/spec/unit/hanami/utils/class_attribute/attributes_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/class_attribute/attributes"
 
 RSpec.describe Hanami::Utils::ClassAttribute::Attributes do

--- a/spec/unit/hanami/utils/class_attribute_spec.rb
+++ b/spec/unit/hanami/utils/class_attribute_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/class_attribute"
 
 RSpec.describe Hanami::Utils::ClassAttribute do

--- a/spec/unit/hanami/utils/class_spec.rb
+++ b/spec/unit/hanami/utils/class_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/class"
 require "hanami/utils/io"
 

--- a/spec/unit/hanami/utils/deprecation_spec.rb
+++ b/spec/unit/hanami/utils/deprecation_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/deprecation"
 
 class DeprecationTest
@@ -25,11 +23,11 @@ end
 RSpec.describe Hanami::Utils::Deprecation do
   it "prints a deprecation warning for direct call" do
     expect { DeprecationTest.new.old_method }
-      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:27")).to_stderr
+      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:25")).to_stderr
   end
 
   it "prints a deprecation warning for nested call" do
     expect { DeprecationWrapperTest.new.run }
-      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:21:in `run'.")).to_stderr
+      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:19:in `run'.")).to_stderr
   end
 end

--- a/spec/unit/hanami/utils/file_list_spec.rb
+++ b/spec/unit/hanami/utils/file_list_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/file_list"
 require "pathname"
 

--- a/spec/unit/hanami/utils/files_spec.rb
+++ b/spec/unit/hanami/utils/files_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/files"
 require "securerandom"
 require "hanami/utils/io"
@@ -193,10 +191,8 @@ RSpec.describe Hanami::Utils::Files do
       EOF
 
       described_class.write(path, content)
-      described_class.unshift(path, "# frozen_string_literal: true")
 
       expected = <<~EOF
-        # frozen_string_literal: true
         class Unshift
         end
       EOF

--- a/spec/unit/hanami/utils/hash_spec.rb
+++ b/spec/unit/hanami/utils/hash_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "bigdecimal"
 require "ostruct"
 require "hanami/utils/hash"

--- a/spec/unit/hanami/utils/io_spec.rb
+++ b/spec/unit/hanami/utils/io_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/io"
 
 class IOTest

--- a/spec/unit/hanami/utils/kernel_spec.rb
+++ b/spec/unit/hanami/utils/kernel_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "ostruct"
 require "bigdecimal"
 require "securerandom"

--- a/spec/unit/hanami/utils/load_paths_spec.rb
+++ b/spec/unit/hanami/utils/load_paths_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/load_paths"
 
 Hanami::Utils::LoadPaths.class_eval do

--- a/spec/unit/hanami/utils/path_prefix_spec.rb
+++ b/spec/unit/hanami/utils/path_prefix_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/path_prefix"
 
 RSpec.describe Hanami::Utils::PathPrefix do

--- a/spec/unit/hanami/utils/query_string_spec.rb
+++ b/spec/unit/hanami/utils/query_string_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/query_string"
 require "bigdecimal"
 

--- a/spec/unit/hanami/utils/shell_color_spec.rb
+++ b/spec/unit/hanami/utils/shell_color_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/shell_color"
 
 RSpec.describe Hanami::Utils::ShellColor do

--- a/spec/unit/hanami/utils/string_spec.rb
+++ b/spec/unit/hanami/utils/string_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/string"
 
 RSpec.describe Hanami::Utils::String do

--- a/spec/unit/hanami/utils/utils_spec.rb
+++ b/spec/unit/hanami/utils/utils_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Utils do
   describe ".jruby?" do
     it "introspects the current platform" do

--- a/spec/unit/hanami/utils/version_spec.rb
+++ b/spec/unit/hanami/utils/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::Utils::VERSION" do
   it "exposes version" do
     expect(Hanami::Utils::VERSION).to eq("2.0.3")


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.