### PR TITLE
Add support for Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"

--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-core", "~> 1.0", "< 2"
   spec.add_dependency "dry-transformer", "~> 1.0", "< 2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_dependency "bigdecimal", "~> 3.1"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 13"

--- a/spec/unit/hanami/utils/deprecation_spec.rb
+++ b/spec/unit/hanami/utils/deprecation_spec.rb
@@ -29,7 +29,16 @@ RSpec.describe Hanami::Utils::Deprecation do
   end
 
   it "prints a deprecation warning for nested call" do
-    expect { DeprecationWrapperTest.new.run }
-      .to output(include("old_method is deprecated, please use new_method - called from: #{__FILE__}:21:in `run'.")).to_stderr
+    if RUBY_VERSION < "3.4"
+      expect { DeprecationWrapperTest.new.run }
+        .to output(
+          include("old_method is deprecated, please use new_method - called from: #{__FILE__}:21:in `run'.")
+        ).to_stderr
+    else
+      expect { DeprecationWrapperTest.new.run }
+        .to output(
+          include("old_method is deprecated, please use new_method - called from: #{__FILE__}:21:in 'DeprecationWrapperTest#run'.")
+        ).to_stderr
+    end
   end
 end

--- a/spec/unit/hanami/utils/kernel_spec.rb
+++ b/spec/unit/hanami/utils/kernel_spec.rb
@@ -1400,7 +1400,11 @@ RSpec.describe Hanami::Utils::Kernel do
         let(:input) { {a: 1, "b" => 2} }
 
         it "returns the string representation" do
-          expect(@result).to eq '{:a=>1, "b"=>2}'
+          if RUBY_VERSION < "3.4"
+            expect(@result).to eq '{:a=>1, "b"=>2}'
+          else
+            expect(@result).to eq '{a: 1, "b" => 2}'
+          end
         end
       end
 


### PR DESCRIPTION
We still get ostruct warnings but it's only used in a couple specs so I think we should rework the specs to not use OpenStruct... or we could just add it to the Gemfile because it's a _default_ gem. Which do you think is better? Feel free to make either change to this PR or defer to a future PR since it's just a warning.

Note that we have to add the dependency on bigdecimal because it's a _bundled_ gem, which means [it's installed with ruby but it can be removed by users](https://stdgems.org/). If users removed it, then our dependency is missing and this library breaks. So we have define it in the gemspec.
