### PR TITLE
Fix deprecations for JRuby 10.1

### DIFF
--- a/lib/hanami/utils/deprecation.rb
+++ b/lib/hanami/utils/deprecation.rb
@@ -67,7 +67,7 @@ module Hanami
 
       # @api private
       def caller_index
-        if RUBY_VERSION >= "4.0"
+        if RUBY_VERSION >= "4.0" && RUBY_ENGINE != "jruby"
           1
         else
           2


### PR DESCRIPTION
JRuby targets Ruby 4.0 compatibility, but it still displays old behaviour around caller inside .new (likely a bug). This ensures old behaviour for JRuby.