### PR TITLE
Drop gson support for JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,6 @@ group :multi_json do
   gem "multi_json", "~> 1.0", require: false
 end
 
-gem "gson", ">= 0.6", platforms: :jruby
-
 group :test do
   gem "rspec", "~> 3.9"
 end

--- a/spec/isolation/hanami/utils/json/multi_json_spec.rb
+++ b/spec/isolation/hanami/utils/json/multi_json_spec.rb
@@ -3,7 +3,6 @@
 require_relative "#{__dir__}../../../../../support/isolation_spec_helper"
 Bundler.require(:default, :development, :multi_json)
 
-require "gson" if Hanami::Utils.jruby?
 require "hanami/utils/json"
 
 RSpec.describe Hanami::Utils::Json do


### PR DESCRIPTION
gson has not seen any development in 13 years and uses APIs that were removed in JRuby 10.1. As such it's not really helpful here in tests. We will let multi_json to pick default JSON implementation for JRuby.