### PR TITLE
Allow bigdecimal 4 or 3

### DIFF
--- a/hanami-utils.gemspec
+++ b/hanami-utils.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-core", "~> 1.0", "< 2"
   spec.add_runtime_dependency "dry-transformer", "~> 1.0", "< 2"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "bigdecimal", "~> 3.1"
+  spec.add_runtime_dependency "bigdecimal", ">= 3.1"
 end
 

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -12,4 +12,4 @@ gemspec:
     - ["dry-core", "~> 1.0", "< 2"]
     - ["dry-transformer", "~> 1.0", "< 2"]
     - ["concurrent-ruby", "~> 1.0"]
-    - ["bigdecimal", "~> 3.1"]
+    - ["bigdecimal", ">= 3.1"]


### PR DESCRIPTION
It would be nice to be able to use the latest and greatest `bigdecimal` with Hanami.  All of the tests around bigdecimal pass for me with bigdecimal 4